### PR TITLE
Use Docker on Travis

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:xenial
+
+RUN apt update -y && apt install -y g++ cmake

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+set -x
+
+mkdir build
+cd build
+cmake -DJulia_EXECUTABLE=$(which julia) ..
+VERBOSE=ON cmake --build . --config Debug --target all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,28 @@
-language: cpp
-matrix:
-  include:
-    - os: linux
-      compiler: "g++-4.9"
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
-          packages:
-            - g++-4.9
-            - cmake
-            - cmake-data
-      env:
-        - CC=gcc-4.9
-        - CXX=g++-4.9
-      before_install:
-        - CURL_USER_AGENT="Travis-CI $(curl --version | head -n 1)"
-        - mkdir -p ~/julia
-        - curl -A "$CURL_USER_AGENT" -s -L --retry 7 'https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6-latest-linux-x86_64.tar.gz' | tar -C ~/julia -x -z --strip-components=1 -f -
-    - os: osx
-      compiler: "clang"
-      before_install:
-        - CURL_USER_AGENT="Travis-CI $(curl --version | head -n 1)"
-        - curl -A "$CURL_USER_AGENT" -s -L --retry 7 -o julia.dmg 'https://julialang-s3.julialang.org/bin/mac/x64/0.6/julia-0.6-latest-mac64.dmg'
-        - mkdir juliamnt
-        - hdiutil mount -readonly -mountpoint juliamnt julia.dmg
-        - cp -a juliamnt/*.app/Contents/Resources/julia ~/
+language: julia
+julia:
+  # Test against these exact versions
+  - 0.6.1
+  - 0.6.2
+  - 0.6.3
+dist: trusty
+sudo: false
+os:
+  - linux
+  - osx
 
 install:
-  - mkdir build
-  - cd build
-  - cmake -DJulia_EXECUTABLE=$HOME/julia/bin/julia ..
-  - VERBOSE=ON cmake --build . --config Debug --target all
+  # On Linux, do the build within docker, on OSX just run the build directly
+  - if [ $(uname) == Linux ]; then
+        docker build -t ubuntu_with_cmake .ci;
+        DOCKER_PATH=$(docker run -t ubuntu_with_cmake /bin/sh -c 'echo -n "$PATH"');
+        JULIA_DIR=$(dirname $(dirname $(which julia)));
+        docker run -t -e PATH="${JULIA_DIR}/bin:${DOCKER_PATH}" -v ${JULIA_DIR}:${JULIA_DIR} -v $(pwd):$(pwd) -w $(pwd) ubuntu_with_cmake .ci/build.sh;
+    elif [ $(uname) == Darwin ]; then
+      .ci/build.sh;
+    fi
 
 script:
-  ctest -V
+  - cd build && ctest -V
 
 notifications:
   email: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ target_include_directories(${JLCXX_TARGET} PUBLIC
 generate_export_header(${JLCXX_TARGET})
 
 target_link_libraries(${JLCXX_TARGET} $<BUILD_INTERFACE:${Julia_LIBRARY}>)
+link_directories(${Julia_LIBRARY_DIR} ${Julia_LIBRARY_DIR}/julia)
 set_target_properties(${JLCXX_TARGET} PROPERTIES
                       PUBLIC_HEADER "${JLCXX_HEADERS}"
                       COMPILE_DEFINITIONS "JLCXX_EXPORTS")


### PR DESCRIPTION
This closes https://github.com/JuliaInterop/libcxxwrap-julia/issues/1

The issue is that GCC, when moving to version 5, [changed the default C++ ABI](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html) to be compatible with the then-new C++ version `c++11`.  For "backwards compatibility" reasons they decided not to bump the SOVERSION of `libstdc++` and kept it at `libstdc++.so.6`; but because the changes were not truly backwards compatible, users must not mix code compiled with the new `cxx11` ABI with code compiled with the old ABI.

Julia used to be compiled with the old ABI, however the compiler landscape eventually moved forward enough that we determined it was worthwhile to drop that restriction.  Starting from Julia 0.6.1, the releases were built with the new cxx11 ABI, which should be the default for any version of GCC >= 5.2.  When I saw the issues in this repository, I thought to myself that it must be as simple as upgrading the `gcc` you're using to `5.4` and changing some compiler flag to say `-D _GLIBCXX_USE_CXX11_ABI=1`, however that didn't work.  It took me a little while to realize that, since the default compilers on Ubuntu precise (and trusty) were both < 5.0, the newer compilers I was downloading from PPAs all had the new cxx11 abi completely disabled.  Even if you explicitly ask for it, the compiler just ignores it and continues to compile against the old abi.  (This is set by [the `--disable-libstdcxx-dual-abi` configure argument](https://gcc.gnu.org/onlinedocs/libstdc++/manual/configure.html) passed to `gcc` at build-time.  You can check for it by running `g++ -v` and looking at the configure line)

This means that, unfortunately, no `g++` compilers you install through any PPA that I searched through will properly link against the official julia binaries if you're running on Ubuntu Precise or Trusty.  There is a workaround, which is to tell the compiler to link against the `libstdc++.so.6` that comes with Julia (e.g. just pass that file in as another input file to your failing `g++` command) and that works, but I think that mostly works because you are not actually compiling any new C++ source code that makes use of the cxx11 abi here, you're just relinking LLVM code that has already been compiled and uses it, and `g++` is complaining that it's default internal `libstdc++` doesn't have those methods available.

The better solution, in my opinion, is to use a slightly newer version of Ubuntu as the build environment.  This PR adds a `.ci` folder that has a `Dockerfile` within it and a `build.sh` script.  The `Dockerfile` is used to download and install `g++` and `cmake` within a docker image, which is then used to build the `libcxxwrap` library.  To prove that the built library is good and usable anywhere, the tests are run outside of the docker environment.

If you have any questions about this, please do not hesitate to ask.  I spent a good while researching why exactly this was breaking on Ubuntu when it worked fine on my local (non-Ubuntu) machines, so I've likely got most of the answers cached in my mind already.  :)