### PR TITLE
Add `-std=c++14` flag using `target_compile_options()`, only to cpp sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ set_property(TARGET ${JLCXX_TARGET} APPEND PROPERTY
   COMPATIBLE_INTERFACE_STRING ${JLCXX_TARGET}_MAJOR_VERSION
 )
 target_compile_definitions(${JLCXX_TARGET} PUBLIC "JULIA_ENABLE_THREADING")
-target_compile_options(${JLCXX_TARGET} PUBLIC "-std=c++14")
+target_compile_options(${JLCXX_TARGET} PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:-std=c++14>" )
 
 generate_export_header(${JLCXX_TARGET})
 


### PR DESCRIPTION
This change uses [cmake generator expressions](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html) so that we can set the `-std=c++14` flag as `PUBLIC` on `jlcxx` target, without adversely affecting non-cpp files that get linked in.

This way anything that depends on `jlcxx` will automatically be compiled with the same cpp langage.

Without this change, using `jlcxx` in a project that has some `C/ObjC` will result in the following error (tested on macOS with `Apple LLVM version 9.0.0 (clang-900.0.39.2)`):

```julia
error: invalid argument '-std=c++14' not allowed with 'C/ObjC'
```