### PR TITLE
Simulate an externally built dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/testlib-builder/build
+/testlib-builder/products

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ before_script:
 
 script:
   - julia --color=yes JuliaInterop/libcxxwrap-julia/.ci/build_tarballs.jl
+  - cd JuliaInterop/libcxxwrap-julia/testlib-builder
+  - julia --color=yes build_tarballs.jl
+  - cd ../../..
   - ls -l products
 
 deploy:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JlCxx
 
-[![Build Status](https://travis-ci.org/JuliaInterop/libcxxwrap-julia.svg?branch=master)](https://travis-ci.org/JuliaInterop/libcxxwrap-julia.svg)
+[![Build Status](https://travis-ci.org/JuliaInterop/libcxxwrap-julia.svg?branch=master)](https://travis-ci.org/JuliaInterop/libcxxwrap-julia)
 [![Build status](https://ci.appveyor.com/api/projects/status/96h6josegra2ct2d?svg=true)](https://ci.appveyor.com/project/barche/libcxxwrap-julia)
 
 This is the C++ library component of the [CxxWrap.jl](https://github.com/JuliaInterop/CxxWrap.jl) package, distributed as a regular CMake library

--- a/testlib-builder/build_tarballs.jl
+++ b/testlib-builder/build_tarballs.jl
@@ -1,0 +1,60 @@
+using BinaryBuilder
+
+sources = [
+    "src"
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain -DCMAKE_CXX_FLAGS="-march=x86-64" -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_FIND_ROOT_PATH=${prefix} -DJulia_ROOT=${prefix} ../testlib
+VERBOSE=ON cmake --build . --config Release --target install
+"""
+
+version_number = get(ENV, "TRAVIS_TAG", "")
+if version_number == ""
+    version_number = "v0.99.0"
+end
+
+# This transforms the dependency script to use the binaries generated in the same Travis run
+@show ws_root = dirname(dirname(dirname(dirname(@__FILE__))))
+@show prod_dir = joinpath(ws_root, "products")
+@show generated_script_name = joinpath(prod_dir,"build_libcxxwrap-julia-1.0.$(version_number).jl")
+local_dep_script = ""
+open(generated_script_name, "r") do generated_script
+    while !eof(generated_script)
+        l = readline(generated_script; keep=true)
+        if startswith(l, "bin_prefix = \"https://github.com")
+            l = "bin_prefix = \"$prod_dir\"\n"
+        end
+        global local_dep_script *= l
+    end
+end
+
+# These are the platforms we will build for by default, unless further
+# platforms are passed in on the command line
+platforms = Platform[]
+_abis(p) = (:gcc7,:gcc8)
+_archs(p) = (:x86_64, :i686)
+_archs(::Type{Linux}) = (:x86_64,)
+for p in (Linux,Windows)
+    for a in _archs(p)
+        for abi in _abis(p)
+            push!(platforms, p(a, compiler_abi=CompilerABI(abi,:cxx11)))
+        end
+    end
+end
+push!(platforms, MacOS(:x86_64))
+
+# The products that we will ensure are always built
+products = prefix -> [
+    LibraryProduct(prefix, "testlib", :testlib),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+   "https://github.com/JuliaPackaging/JuliaBuilder/releases/download/v1.0.0-2/build_Julia.v1.0.0.jl",
+   BinaryBuilder.InlineBuildDependency(local_dep_script)
+]
+
+build_tarballs(ARGS, "testlib", VersionNumber(version_number), sources, script, platforms, products, dependencies)

--- a/testlib-builder/src/testlib/CMakeLists.txt
+++ b/testlib-builder/src/testlib/CMakeLists.txt
@@ -1,0 +1,22 @@
+project(TestLib)
+
+cmake_minimum_required(VERSION 2.8.12)
+set(CMAKE_MACOSX_RPATH 1)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+
+find_package(JlCxx)
+get_target_property(JlCxx_location JlCxx::cxxwrap_julia LOCATION)
+get_filename_component(JlCxx_location ${JlCxx_location} DIRECTORY)
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${JlCxx_location}")
+
+message(STATUS "Found JlCxx at ${JlCxx_location}")
+
+add_library(testlib SHARED testlib.cpp)
+
+target_link_libraries(testlib JlCxx::cxxwrap_julia)
+
+install(TARGETS
+  testlib
+LIBRARY DESTINATION lib
+ARCHIVE DESTINATION lib
+RUNTIME DESTINATION lib)

--- a/testlib-builder/src/testlib/testlib.cpp
+++ b/testlib-builder/src/testlib/testlib.cpp
@@ -1,0 +1,9 @@
+#include "jlcxx/jlcxx.hpp"
+
+struct MyStruct {};
+
+JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
+{
+  mod.add_type<MyStruct>("MyStruct");
+  mod.method("greet", []() {return "Hello";});
+}


### PR DESCRIPTION
This tries to build a test library making use of the libcxxwrap-julia binaries, in an attempt to test and guard against issues like #13.