### PR TITLE
array_iterator_base: value_type should be CppT

### DIFF
--- a/include/jlcxx/array.hpp
+++ b/include/jlcxx/array.hpp
@@ -27,7 +27,7 @@ struct ValueExtractor<PointedT, PointedT>
 };
 
 template<typename PointedT, typename CppT>
-class array_iterator_base : public std::iterator<std::random_access_iterator_tag, PointedT>
+class array_iterator_base : public std::iterator<std::random_access_iterator_tag, CppT>
 {
 private:
   PointedT* m_ptr;


### PR DESCRIPTION
It is supposed to be an (iterator over) an STL compatible container
with CppT elements but value_type appears to be something like
jlcxx::WrappedCppPtr