### PR TITLE
Use other variable name than Julia_ROOT

### DIFF
--- a/.ci/build_tarballs.jl
+++ b/.ci/build_tarballs.jl
@@ -9,8 +9,8 @@ sources = [
 function getscript(version)
     shortversion = version[1:3]
     return """
-    Julia_ROOT=\$prefix
-    # Julia_ROOT=/usr/local
+    Julia_PREFIX=\$prefix
+
 
     # Download julia
     #cd /usr/local
@@ -19,7 +19,7 @@ function getscript(version)
     # Build libcxxwrap
     cd \$WORKSPACE/srcdir/libcxxwrap-julia*
     mkdir build && cd build
-    cmake -DJulia_ROOT=\$Julia_ROOT -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=/opt/\$target/\$target.toolchain -DCMAKE_CXX_FLAGS="-march=x86-64" -DCMAKE_INSTALL_PREFIX=\${prefix} ..
+    cmake -DJulia_PREFIX=\$Julia_PREFIX -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=/opt/\$target/\$target.toolchain -DCMAKE_CXX_FLAGS="-march=x86-64" -DCMAKE_INSTALL_PREFIX=\${prefix} ..
     VERBOSE=ON cmake --build . --config Release --target install
     if [[ "\$target" == "x86_64-linux-gnu" ]]; then
         ctest -V

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(JlCxx)
 
+# Cmake policies
+# ==============
+
+if(POLICY CMP0074)
+    # find_package() uses <PackageName>_ROOT variables.
+    # This policy was introduced in CMake version 3.12.
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 # Dependencies
 # ============
 
@@ -19,7 +28,6 @@ include(CMakePackageConfigHelpers)
 include(GenerateExportHeader)
 include(GNUInstallDirs)
 include(InstallRequiredSystemLibraries)
-
 
 # Compilation flags
 # =================

--- a/FindJulia.cmake
+++ b/FindJulia.cmake
@@ -9,11 +9,13 @@ endif()
 # Julia Executable #
 ####################
 
-if(Julia_ROOT)
-    message(STATUS "Adding path ${Julia_ROOT} to search path")
-    list(APPEND CMAKE_PREFIX_PATH ${Julia_ROOT})
+if(Julia_PREFIX)
+    message(STATUS "Adding path ${Julia_PREFIX} to search path")
+    list(APPEND CMAKE_PREFIX_PATH ${Julia_PREFIX})
+    message(STATUS "THIS BRANCH")
 else()
     find_program(Julia_EXECUTABLE julia DOC "Julia executable")
+    message(STATUS "Found Julia executable: " ${Julia_EXECUTABLE})
 endif()
 
 #################
@@ -69,8 +71,8 @@ elseif(Julia_EXECUTABLE)
     string(REGEX REPLACE "\n" "" Julia_INCLUDE_DIRS "${Julia_INCLUDE_DIRS}")
     set(Julia_INCLUDE_DIRS ${Julia_INCLUDE_DIRS}
         CACHE PATH "Location of Julia include files")
-elseif(Julia_ROOT)
-    set(Julia_INCLUDE_DIRS ${Julia_ROOT}/include/julia)
+elseif(Julia_PREFIX)
+    set(Julia_INCLUDE_DIRS ${Julia_PREFIX}/include/julia)
 endif()
 MESSAGE(STATUS "Julia_INCLUDE_DIRS:   ${Julia_INCLUDE_DIRS}")
 

--- a/JlCxxConfig.cmake.in
+++ b/JlCxxConfig.cmake.in
@@ -1,5 +1,4 @@
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-set(Julia_EXECUTABLE   "@Julia_EXECUTABLE@" )
 find_package(Julia)
 
 include(JlCxxConfigExports)

--- a/testlib-builder/build_tarballs.jl
+++ b/testlib-builder/build_tarballs.jl
@@ -7,7 +7,7 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain -DCMAKE_CXX_FLAGS="-march=x86-64" -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_FIND_ROOT_PATH=${prefix} -DJulia_ROOT=${prefix} ../testlib
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain -DCMAKE_CXX_FLAGS="-march=x86-64" -DCMAKE_INSTALL_PREFIX=${prefix} -DCMAKE_FIND_ROOT_PATH=${prefix} -DJulia_PREFIX=${prefix} ../testlib
 VERBOSE=ON cmake --build . --config Release --target install
 """
 


### PR DESCRIPTION
`Julia_ROOT` is now a reserved variable used by `find_package`(more generally `packagename_ROOT`), and it is always set by cmake from 3.12.

This caused the `Julia_EXECUTABLE` to not be properly set by `FindJulia.cmake`.

Fixing this makes the manual setting of `Julia_EXECUTABLE` in the config cmake file unnecessary.