### PR TITLE
Fix JlCxxConfig.cmake changing CMAKE_MODULE_PATH

### DIFF
--- a/JlCxxConfig.cmake.in
+++ b/JlCxxConfig.cmake.in
@@ -1,7 +1,10 @@
+set(_OLD_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_package(Julia)
 
 include(JlCxxConfigExports)
+
+set(CMAKE_MODULE_PATH ${_OLD_CMAKE_MODULE_PATH})
 
 get_target_property(CXX_OLD_INCLUDES JlCxx::cxxwrap_julia INTERFACE_INCLUDE_DIRECTORIES)
 


### PR DESCRIPTION
This commit ensures that JlCxxConfig.cmake does not overwrite the
`CMAKE_MODULE_PATH` set up by the outside environment, which is required
if the caller tries to use `find_package` after loading the JlCxx package.