### PR TITLE
Implement postfix++/-- in array_iterator_base

### DIFF
--- a/include/jlcxx/array.hpp
+++ b/include/jlcxx/array.hpp
@@ -54,10 +54,24 @@ public:
     return *this;
   }
 
+  array_iterator_base<PointedT, CppT> operator++(int)
+  {
+    auto result(*this);
+    ++(*this);
+    return result;
+  }
+
   array_iterator_base<PointedT, CppT>& operator--()
   {
     --m_ptr;
     return *this;
+  }
+
+  array_iterator_base<PointedT, CppT> operator--(int)
+  {
+    auto result(*this);
+    --(*this);
+    return result;
   }
 
   array_iterator_base<PointedT, CppT>& operator+=(std::ptrdiff_t n)


### PR DESCRIPTION
Took the liberty of submitting a PR aiming to complement / fix #58 using the patch described in said issue.

Usage of `auto` can be dropped in favor of explicit typing, if preferrable. Just felt like avoiding redundancy.