### PR TITLE
construct std::stringstream from ""

### DIFF
--- a/include/jlcxx/type_conversion.hpp
+++ b/include/jlcxx/type_conversion.hpp
@@ -172,7 +172,7 @@ inline CppT* extract_pointer_nonull(const WrappedCppPtr& p)
 {
   if(p.voidptr == nullptr)
   {
-    std::stringstream errorstr;
+    std::stringstream errorstr("");
     errorstr << "C++ object of type " << typeid(CppT).name() << " was deleted";
     throw std::runtime_error(errorstr.str());
   }


### PR DESCRIPTION
we applied such fix in https://github.com/oscar-system/Polymake.jl/pull/252 due to https://github.com/oscar-system/Polymake.jl/issues/251