### PR TITLE
Remove non-standard BOMs from C++ source files

### DIFF
--- a/examples/basic_types.cpp
+++ b/examples/basic_types.cpp
@@ -1,4 +1,4 @@
-﻿#include <algorithm>
+#include <algorithm>
 
 #include "jlcxx/jlcxx.hpp"
 #include "jlcxx/functions.hpp"

--- a/examples/containers.cpp
+++ b/examples/containers.cpp
@@ -1,4 +1,4 @@
-﻿#include <tuple>
+#include <tuple>
 
 #include "jlcxx/array.hpp"
 #include "jlcxx/jlcxx.hpp"

--- a/examples/except.cpp
+++ b/examples/except.cpp
@@ -1,4 +1,4 @@
-﻿#include <iostream>
+#include <iostream>
 #include <stdexcept>
 #include <julia.h>
 

--- a/examples/extended.cpp
+++ b/examples/extended.cpp
@@ -1,4 +1,4 @@
-﻿#include <string>
+#include <string>
 
 #include "jlcxx/jlcxx.hpp"
 

--- a/examples/functions.cpp
+++ b/examples/functions.cpp
@@ -1,4 +1,4 @@
-﻿#include <algorithm>
+#include <algorithm>
 #include <sstream>
 #include <cstddef>
 

--- a/examples/hello.cpp
+++ b/examples/hello.cpp
@@ -1,4 +1,4 @@
-﻿#include <string>
+#include <string>
 
 #include "jlcxx/jlcxx.hpp"
 

--- a/examples/inheritance.cpp
+++ b/examples/inheritance.cpp
@@ -1,4 +1,4 @@
-﻿#include <string>
+#include <string>
 #include <memory>
 
 #include "jlcxx/jlcxx.hpp"

--- a/examples/parametric.cpp
+++ b/examples/parametric.cpp
@@ -1,4 +1,4 @@
-﻿#include <type_traits>
+#include <type_traits>
 
 #include "jlcxx/jlcxx.hpp"
 

--- a/examples/pointer_modification.cpp
+++ b/examples/pointer_modification.cpp
@@ -1,4 +1,4 @@
-﻿#include "jlcxx/jlcxx.hpp"
+#include "jlcxx/jlcxx.hpp"
 
 namespace ptrmodif
 {

--- a/examples/types.cpp
+++ b/examples/types.cpp
@@ -1,4 +1,4 @@
-﻿#include <type_traits>
+#include <type_traits>
 #include <string>
 #include <memory>
 #include <iostream>

--- a/include/jlcxx/array.hpp
+++ b/include/jlcxx/array.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef JLCXX_ARRAY_HPP
+#ifndef JLCXX_ARRAY_HPP
 #define JLCXX_ARRAY_HPP
 
 #include "type_conversion.hpp"

--- a/include/jlcxx/const_array.hpp
+++ b/include/jlcxx/const_array.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef JLCXX_CONST_ARRAY_HPP
+#ifndef JLCXX_CONST_ARRAY_HPP
 #define JLCXX_CONST_ARRAY_HPP
 
 #include "jlcxx.hpp"

--- a/include/jlcxx/functions.hpp
+++ b/include/jlcxx/functions.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef JLCXX_FUNCTIONS_HPP
+#ifndef JLCXX_FUNCTIONS_HPP
 #define JLCXX_FUNCTIONS_HPP
 
 #include <sstream>

--- a/include/jlcxx/jlcxx.hpp
+++ b/include/jlcxx/jlcxx.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef JLCXX_HPP
+#ifndef JLCXX_HPP
 #define JLCXX_HPP
 
 #include <cassert>

--- a/include/jlcxx/module.hpp
+++ b/include/jlcxx/module.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef JLCXX_MODULE_HPP
+#ifndef JLCXX_MODULE_HPP
 #define JLCXX_MODULE_HPP
 
 #include <cassert>

--- a/include/jlcxx/smart_pointers.hpp
+++ b/include/jlcxx/smart_pointers.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef JLCXX_SMART_POINTER_HPP
+#ifndef JLCXX_SMART_POINTER_HPP
 #define JLCXX_SMART_POINTER_HPP
 
 #include "module.hpp"

--- a/include/jlcxx/stl.hpp
+++ b/include/jlcxx/stl.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef JLCXX_STL_HPP
+#ifndef JLCXX_STL_HPP
 #define JLCXX_STL_HPP
 
 #include <valarray>

--- a/include/jlcxx/tuple.hpp
+++ b/include/jlcxx/tuple.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef JLCXX_TUPLE_HPP
+#ifndef JLCXX_TUPLE_HPP
 #define JLCXX_TUPLE_HPP
 
 #include <tuple>

--- a/include/jlcxx/type_conversion.hpp
+++ b/include/jlcxx/type_conversion.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef JLCXX_TYPE_CONVERSION_HPP
+#ifndef JLCXX_TYPE_CONVERSION_HPP
 #define JLCXX_TYPE_CONVERSION_HPP
 
 #include <julia.h>

--- a/src/c_interface.cpp
+++ b/src/c_interface.cpp
@@ -1,4 +1,4 @@
-﻿#include "jlcxx/array.hpp"
+#include "jlcxx/array.hpp"
 #include "jlcxx/jlcxx.hpp"
 #include "jlcxx/jlcxx_config.hpp"
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1,4 +1,4 @@
-﻿#include "jlcxx/functions.hpp"
+#include "jlcxx/functions.hpp"
 #include "jlcxx/module.hpp"
 
 // This header provides helper functions to call Julia functions from C++

--- a/src/jlcxx.cpp
+++ b/src/jlcxx.cpp
@@ -1,4 +1,4 @@
-﻿#include "jlcxx/array.hpp"
+#include "jlcxx/array.hpp"
 #include "jlcxx/jlcxx.hpp"
 #include "jlcxx/functions.hpp"
 #include "jlcxx/jlcxx_config.hpp"


### PR DESCRIPTION
BOMs (byte order markers) were originally designed for UTF-16 and UTF-32
to be able to deal with both big endian and little endian variants. To
this end, the value 0xFEFF is written as a 16bit or 32bit word at the
start of a text file. By inspecting the first bytes of the file, a text
editor can then determine if the file was written in little or big
endian mode.

For UTF-8, this was never necessary or useful. However, there is still a
BOM standardized for UTF-8, to be able to explicitly mark a file as
being UTF-8 encoded; for this the *byte* sequence EF BB BF has to be at
the start of the file. However, using a UTF-8 BOM is generally not
recommended. Alas, Microsoft tools for some reason insist on it
(presumably due to the historic use of UTF-16 (resp. UCS-2) as default
encoding in Windows.

What is never correct, however, is to put UTF-16 BOMs into file using
UTF-8 encoding. Thus this patch removes non-standard UTF-16 BOMs 0xFEFF
from several source files.