### PR TITLE
Add JL_GC_PUSH / JL_GC_POP calls, reduce usage of jl_svec1

### DIFF
--- a/include/jlcxx/array.hpp
+++ b/include/jlcxx/array.hpp
@@ -280,7 +280,7 @@ struct PackedArrayType<T*, WrappedPtrTrait>
 {
   static jl_datatype_t* type()
   {
-    return apply_type1(jlcxx::julia_type("Ptr"), julia_base_type<T>());
+    return apply_type(jlcxx::julia_type("Ptr"), julia_base_type<T>());
   }
 };
 

--- a/include/jlcxx/array.hpp
+++ b/include/jlcxx/array.hpp
@@ -280,7 +280,7 @@ struct PackedArrayType<T*, WrappedPtrTrait>
 {
   static jl_datatype_t* type()
   {
-    return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("Ptr"), jl_svec1(julia_base_type<T>()));
+    return apply_type1(jlcxx::julia_type("Ptr"), julia_base_type<T>());
   }
 };
 

--- a/include/jlcxx/const_array.hpp
+++ b/include/jlcxx/const_array.hpp
@@ -85,10 +85,10 @@ struct ConvertToJulia<ConstArray<T,N>, ConstArrayTrait>
 {
   jl_value_t* operator()(const ConstArray<T,N>& arr)
   {
-    jl_value_t* result = nullptr;
+    jl_value_t* result;
     jl_value_t* ptr = nullptr;
     jl_value_t* size = nullptr;
-    JL_GC_PUSH3(&result, &ptr, &size);
+    JL_GC_PUSH2(&ptr, &size);
     ptr = box<const T*>(arr.ptr());
     size = convert_to_julia(arr.size());
     result = jl_new_struct(julia_type<ConstArray<T,N>>(), ptr, size);
@@ -109,8 +109,14 @@ struct julia_type_factory<ConstArray<T,N>, ConstArrayTrait>
   static jl_datatype_t* julia_type()
   {
     create_if_not_exists<T>();
-    jl_datatype_t* pdt = (jl_datatype_t*)::jlcxx::julia_type("ConstArray");
-    return  (jl_datatype_t*)apply_type((jl_value_t*)pdt, jl_svec2(::jlcxx::julia_type<T>(), box<index_t>(N)));
+    jl_value_t* pdt = ::jlcxx::julia_type("ConstArray");
+    jl_value_t* val = box<index_t>(N);
+    jl_value_t* result;
+    JL_GC_PUSH1(&val);
+    jl_value_t* t[2] = { (jl_value_t*)::jlcxx::julia_type<T>(), val };
+    result = apply_type(pdt, t, 2);
+    JL_GC_POP();
+    return (jl_datatype_t*)result;
   }
 };
 

--- a/include/jlcxx/type_conversion.hpp
+++ b/include/jlcxx/type_conversion.hpp
@@ -88,7 +88,7 @@ JLCXX_API jl_value_t* apply_type(jl_value_t* tc, jl_svec_t* params);
 
 //
 JLCXX_API jl_value_t* apply_type(jl_value_t* tc, jl_value_t **params, size_t n);
-JLCXX_API jl_datatype_t* apply_type1(jl_value_t* tc, jl_datatype_t *type);
+JLCXX_API jl_datatype_t* apply_type(jl_value_t* tc, jl_datatype_t *type);
 
 
 /// Get the type from a global symbol
@@ -506,7 +506,7 @@ struct julia_type_factory<const SourceT&>
 {
   static inline jl_datatype_t* julia_type()
   {
-    return apply_type1(jlcxx::julia_type("ConstCxxRef"), julia_base_type<SourceT>());
+    return apply_type(jlcxx::julia_type("ConstCxxRef"), julia_base_type<SourceT>());
   }
 };
 
@@ -516,7 +516,7 @@ struct julia_type_factory<SourceT&>
 {
   static inline jl_datatype_t* julia_type()
   {
-    return apply_type1(jlcxx::julia_type("CxxRef"), julia_base_type<SourceT>());
+    return apply_type(jlcxx::julia_type("CxxRef"), julia_base_type<SourceT>());
   }
 };
 
@@ -526,7 +526,7 @@ struct julia_type_factory<const SourceT*>
 {
   static inline jl_datatype_t* julia_type()
   {
-    return apply_type1(jlcxx::julia_type("ConstCxxPtr"), julia_base_type<SourceT>());
+    return apply_type(jlcxx::julia_type("ConstCxxPtr"), julia_base_type<SourceT>());
   }
 };
 
@@ -536,7 +536,7 @@ struct julia_type_factory<SourceT*>
 {
   static inline jl_datatype_t* julia_type()
   {
-    return apply_type1(jlcxx::julia_type("CxxPtr"), julia_base_type<SourceT>());
+    return apply_type(jlcxx::julia_type("CxxPtr"), julia_base_type<SourceT>());
   }
 };
 
@@ -1015,7 +1015,7 @@ struct julia_type_factory<SingletonType<T>>
 {
   static inline jl_datatype_t* julia_type()
   {
-    return apply_type1((jl_value_t *)jl_type_type, ::jlcxx::julia_base_type<T>());
+    return apply_type((jl_value_t *)jl_type_type, ::jlcxx::julia_base_type<T>());
   }
 };
 
@@ -1063,7 +1063,7 @@ template<typename NumberT> struct julia_type_factory<StrictlyTypedNumber<NumberT
 {
   static jl_datatype_t* julia_type()
   {
-    return apply_type1(::jlcxx::julia_type("StrictlyTypedNumber"), ::jlcxx::julia_type<NumberT>());
+    return apply_type(::jlcxx::julia_type("StrictlyTypedNumber"), ::jlcxx::julia_type<NumberT>());
   }
 };
 
@@ -1073,7 +1073,7 @@ template<typename NumberT> struct julia_type_factory<std::complex<NumberT>>
 {
   static jl_datatype_t* julia_type()
   {
-    return apply_type1(jlcxx::julia_type("Complex"), ::jlcxx::julia_type<NumberT>());
+    return apply_type(jlcxx::julia_type("Complex"), ::jlcxx::julia_type<NumberT>());
   }
 };
 

--- a/include/jlcxx/type_conversion.hpp
+++ b/include/jlcxx/type_conversion.hpp
@@ -86,6 +86,11 @@ inline std::string module_name(jl_module_t* mod)
 /// Backwards-compatible apply_type
 JLCXX_API jl_value_t* apply_type(jl_value_t* tc, jl_svec_t* params);
 
+//
+JLCXX_API jl_value_t* apply_type(jl_value_t* tc, jl_value_t **params, size_t n);
+JLCXX_API jl_datatype_t* apply_type1(jl_value_t* tc, jl_datatype_t *type);
+
+
 /// Get the type from a global symbol
 JLCXX_API jl_value_t* julia_type(const std::string& name, const std::string& module_name = "");
 JLCXX_API jl_value_t* julia_type(const std::string& name, jl_module_t* mod);
@@ -501,7 +506,7 @@ struct julia_type_factory<const SourceT&>
 {
   static inline jl_datatype_t* julia_type()
   {
-    return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("ConstCxxRef"), jl_svec1(julia_base_type<SourceT>()));
+    return apply_type1(jlcxx::julia_type("ConstCxxRef"), julia_base_type<SourceT>());
   }
 };
 
@@ -511,7 +516,7 @@ struct julia_type_factory<SourceT&>
 {
   static inline jl_datatype_t* julia_type()
   {
-    return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("CxxRef"), jl_svec1(julia_base_type<SourceT>()));
+    return apply_type1(jlcxx::julia_type("CxxRef"), julia_base_type<SourceT>());
   }
 };
 
@@ -521,7 +526,7 @@ struct julia_type_factory<const SourceT*>
 {
   static inline jl_datatype_t* julia_type()
   {
-    return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("ConstCxxPtr"), jl_svec1(julia_base_type<SourceT>()));
+    return apply_type1(jlcxx::julia_type("ConstCxxPtr"), julia_base_type<SourceT>());
   }
 };
 
@@ -531,7 +536,7 @@ struct julia_type_factory<SourceT*>
 {
   static inline jl_datatype_t* julia_type()
   {
-    return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("CxxPtr"), jl_svec1(julia_base_type<SourceT>()));
+    return apply_type1(jlcxx::julia_type("CxxPtr"), julia_base_type<SourceT>());
   }
 };
 
@@ -1010,7 +1015,7 @@ struct julia_type_factory<SingletonType<T>>
 {
   static inline jl_datatype_t* julia_type()
   {
-    return (jl_datatype_t*)apply_type((jl_value_t*)jl_type_type, jl_svec1(::jlcxx::julia_base_type<T>()));
+    return apply_type1((jl_value_t *)jl_type_type, ::jlcxx::julia_base_type<T>());
   }
 };
 
@@ -1058,7 +1063,7 @@ template<typename NumberT> struct julia_type_factory<StrictlyTypedNumber<NumberT
 {
   static jl_datatype_t* julia_type()
   {
-    return (jl_datatype_t*)apply_type((jl_value_t*)::jlcxx::julia_type("StrictlyTypedNumber"), jl_svec1(::jlcxx::julia_type<NumberT>()));
+    return apply_type1(::jlcxx::julia_type("StrictlyTypedNumber"), ::jlcxx::julia_type<NumberT>());
   }
 };
 
@@ -1068,7 +1073,7 @@ template<typename NumberT> struct julia_type_factory<std::complex<NumberT>>
 {
   static jl_datatype_t* julia_type()
   {
-    return (jl_datatype_t*)apply_type(jlcxx::julia_type("Complex"), jl_svec1(::jlcxx::julia_type<NumberT>()));
+    return apply_type1(jlcxx::julia_type("Complex"), ::jlcxx::julia_type<NumberT>());
   }
 };
 

--- a/src/jlcxx.cpp
+++ b/src/jlcxx.cpp
@@ -1,4 +1,4 @@
-#include "jlcxx/array.hpp"
+﻿#include "jlcxx/array.hpp"
 #include "jlcxx/jlcxx.hpp"
 #include "jlcxx/functions.hpp"
 #include "jlcxx/jlcxx_config.hpp"
@@ -219,7 +219,7 @@ JLCXX_API jl_value_t* apply_type(jl_value_t* tc, jl_value_t **params, size_t n)
   return jl_apply_type(jl_is_unionall(tc) ? tc : ((jl_datatype_t*)tc)->name->wrapper, params, n);
 }
 
-JLCXX_API jl_datatype_t* apply_type1(jl_value_t* tc, jl_datatype_t *t)
+JLCXX_API jl_datatype_t* apply_type(jl_value_t* tc, jl_datatype_t *t)
 {
   return (jl_datatype_t*)apply_type(tc, (jl_value_t**)&t, 1);
 }

--- a/src/jlcxx.cpp
+++ b/src/jlcxx.cpp
@@ -208,7 +208,20 @@ JLCXX_API jl_value_t* julia_type(const std::string& name, jl_module_t* mod)
 
 JLCXX_API jl_value_t* apply_type(jl_value_t* tc, jl_svec_t* params)
 {
-  return jl_apply_type(jl_is_unionall(tc) ? tc : ((jl_datatype_t*)tc)->name->wrapper, jl_svec_data(params), jl_svec_len(params));
+  JL_GC_PUSH1((jl_value_t**)&params);
+  jl_value_t* result = apply_type(tc, jl_svec_data(params), jl_svec_len(params));
+  JL_GC_POP();
+  return result;
+}
+
+JLCXX_API jl_value_t* apply_type(jl_value_t* tc, jl_value_t **params, size_t n)
+{
+  return jl_apply_type(jl_is_unionall(tc) ? tc : ((jl_datatype_t*)tc)->name->wrapper, params, n);
+}
+
+JLCXX_API jl_datatype_t* apply_type1(jl_value_t* tc, jl_datatype_t *t)
+{
+  return (jl_datatype_t*)apply_type(tc, (jl_value_t**)&t, 1);
 }
 
 static constexpr const char* dt_prefix = "__cxxwrap_dt_";


### PR DESCRIPTION
Creating a new type or allocating an array might garbage collect the given type unless we GC push/pop it.

Perhaps I am mistaken, though, and these types are in no danger of being GC'ed; in this case I'd appreciate a hint why that is so, to further my understanding of this codebase. Thanks!