### PR TITLE
Added std::thread type to STL module

### DIFF
--- a/src/stl.cpp
+++ b/src/stl.cpp
@@ -64,6 +64,8 @@ JLCXX_MODULE define_cxxwrap_stl_module(jlcxx::Module& stl)
   jlcxx::stl::wrap_string(stl.add_type<std::string>("StdString", julia_type("CppBasicString")));
   jlcxx::stl::wrap_string(stl.add_type<std::wstring>("StdWString", julia_type("CppBasicString")));
 
+  stl.add_type<std::thread>("StdThread");
+
   jlcxx::add_smart_pointer<std::shared_ptr>(stl, "SharedPtr");
   jlcxx::add_smart_pointer<std::weak_ptr>(stl, "WeakPtr");
   jlcxx::add_smart_pointer<std::unique_ptr>(stl, "UniquePtr");


### PR DESCRIPTION
It might be convenient to expose the C++ `std::thread` to Julia, if in need for managing a non-Julia thread from Julia, e.g. instead of passing `void*` back and forth as in https://github.com/IHPSystems/pylon_julia_wrapper/blob/master/src/pylon_wrapper.cpp#L255 and https://github.com/IHPSystems/pylon_julia_wrapper/blob/master/src/pylon_wrapper.cpp#L267

Not sure this PR is even remotely done - more implementation might be needed - and tests or samples.