### PR TITLE
Add support for char16_t and char32_t

### DIFF
--- a/src/jlcxx.cpp
+++ b/src/jlcxx.cpp
@@ -406,6 +406,8 @@ JLCXX_API void register_core_cxxwrap_types()
   {
     set_julia_type<bool>((jl_datatype_t*)julia_type("CxxBool", g_cxxwrap_module));
     set_julia_type<char>((jl_datatype_t*)julia_type("CxxChar", g_cxxwrap_module));
+    set_julia_type<char16_t>((jl_datatype_t*)julia_type("CxxChar16", g_cxxwrap_module));
+    set_julia_type<char32_t>((jl_datatype_t*)julia_type("CxxChar32", g_cxxwrap_module));
     set_julia_type<wchar_t>((jl_datatype_t*)julia_type("CxxWchar", g_cxxwrap_module));
     
     jlcxx::detail::AddIntegerTypes<fundamental_int_types>()("", "Cxx");

--- a/test/test_type_init.cpp
+++ b/test/test_type_init.cpp
@@ -1,17 +1,24 @@
 #include <jlcxx/jlcxx.hpp>
 #include <jlcxx/functions.hpp>
 
+template<typename T>
+void test_type(std::string jl_type_name)
+{
+    if (jlcxx::julia_type_name(jlcxx::julia_type<T>()) != jl_type_name)
+    {
+        throw std::runtime_error(jl_type_name + " type test failed");
+    }
+}
+
 int main()
 {
   jlcxx::cxxwrap_init();
-  if (jlcxx::julia_type_name(jlcxx::julia_type<char>()) != "CxxChar")
-  {
-    throw std::runtime_error("char type test failed");
-  }
-  if(jlcxx::julia_type_name(jlcxx::julia_type<bool>()) != "CxxBool")
-  {
-    throw std::runtime_error("unsigned bool test failed");
-  }
+
+  test_type<char>("CxxChar");
+  test_type<char16_t>("CxxChar16");
+  test_type<char32_t>("CxxChar32");
+  test_type<bool>("CxxBool");
+
   jl_atexit_hook(0);
   return 0;
 }


### PR DESCRIPTION
These were added in C++11: https://en.cppreference.com/w/cpp/language/types.