### PR TITLE
Change julia library search order on Windows

### DIFF
--- a/FindJulia.cmake
+++ b/FindJulia.cmake
@@ -109,7 +109,7 @@ if(Julia_EXECUTABLE)
     set(Julia_LIBRARY "${Julia_LIBRARY}"
         CACHE PATH "Julia library")
 else()
-    find_library(Julia_LIBRARY NAMES libjulia.${Julia_VERSION_STRING}.dylib julia libjulia libjulia.dll.a CMAKE_FIND_ROOT_PATH_BOTH)
+    find_library(Julia_LIBRARY NAMES libjulia.${Julia_VERSION_STRING}.dylib julia libjulia.dll.a libjulia CMAKE_FIND_ROOT_PATH_BOTH)
 endif()
 
 get_filename_component(Julia_LIBRARY_DIR ${Julia_LIBRARY} DIRECTORY)


### PR DESCRIPTION
When using `cmake -DJulia_PREFIX` on Windows, it needs to find `libjulia.dll.a` instead of  `libjulia.dll` to link.
Fix https://github.com/JuliaInterop/CxxWrap.jl/issues/315