### PR TITLE
Added support for Val{T}

### DIFF
--- a/examples/functions.cpp
+++ b/examples/functions.cpp
@@ -307,6 +307,18 @@ JLCXX_MODULE init_test_module(jlcxx::Module& mod)
   mod.method("test_double2_pointer", [] () { return static_cast<double**>(nullptr); });
   mod.method("test_double3_pointer", [] () { return static_cast<double***>(nullptr); });
 
+  // Val
+  mod.method("test_val", [](jlcxx::Val<int, 1>) { return 1; });
+  mod.method("test_val", [](jlcxx::Val<int, 2>) { return jlcxx::Val<int, 2>::jl_value(); });
+  mod.method("test_val", [](jlcxx::Val<short, 3>) { return 3; });
+  mod.method("test_val", [](jlcxx::Val<int, 4>) { return jlcxx::Val<int, 4>(); });
+  JLCXX_VAL_SYM cst_sym_1 = "A";
+  JLCXX_VAL_SYM cst_sym_2 = "B";
+  JLCXX_VAL_SYM cst_sym_3 = "C";
+  mod.method("test_val", [](jlcxx::ValSym<cst_sym_1>) { return (jl_value_t*) jl_symbol("A"); });
+  mod.method("test_val", [](jlcxx::ValSym<cst_sym_2>) { return jlcxx::ValSym<cst_sym_2>::jl_value(); });
+  mod.method("test_val", [](jlcxx::ValSym<cst_sym_3>) { return jlcxx::ValSym<cst_sym_3>(); });
+
   // wstring
   mod.method("test_wstring_to_julia", [] () { return std::wstring(L"šČô_φ_привет_일보"); });
   mod.method("test_wstring_to_cpp", [] (const std::wstring& ws) { return ws == L"šČô_φ_привет_일보"; });


### PR DESCRIPTION
Added support for `jlcxx::Val<T>`, which works nearly identically as `jlcxx::SingletonType<T>`.
All types supported by `jlcxx::box` should also work with `Val<T>`.

A separate specialization using `std::string_view` is used to support symbols too. Because C++ forbids strings of any kind in templates, we are forced to use a `static constexpr const std::string_view` to be able to use it as a template parameter. Since the type is a bit convoluted, I added the `JLCXX_VAL_SYM` macro to simplify the symbol declaration.
Using a `const char[]` would have also been possible, but `JLCXX_VAL_SYM` would get a bit weirder to use, hence the `std::string_view`.