### PR TITLE
Remove an obsolete remark in the README, actually fixing #52.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The file can be generated automatically using the `OVERRIDES_PATH`, `OVERRIDE_RO
 
 ### Building on Windows
 
-On Windows, building is easiest with [Visual Studio 2019](https://visualstudio.microsoft.com/vs/), for which the Community Edition with C++ support is a free download. You can clone the `https://github.com/JuliaInterop/libcxxwrap-julia.git` repository using the [built-in git support](https://docs.microsoft.com/en-us/visualstudio/get-started/tutorial-open-project-from-repo?view=vs-2019), and configure the `Julia_PREFIX` option from the built-in CMake support. See the [Visual Studio docs](https://docs.microsoft.com/en-us/cpp/build/customize-cmake-settings?view=vs-2019) for more info. Use Julia version 1.3.1, otherwise building will fail with "no target architecture" error (see issue [julia/34201](https://github.com/JuliaLang/julia/issues/34201)).
+On Windows, building is easiest with [Visual Studio 2019](https://visualstudio.microsoft.com/vs/), for which the Community Edition with C++ support is a free download. You can clone the `https://github.com/JuliaInterop/libcxxwrap-julia.git` repository using the [built-in git support](https://docs.microsoft.com/en-us/visualstudio/get-started/tutorial-open-project-from-repo?view=vs-2019), and configure the `Julia_PREFIX` option from the built-in CMake support. See the [Visual Studio docs](https://docs.microsoft.com/en-us/cpp/build/customize-cmake-settings?view=vs-2019) for more info. 
 
 See the [CxxWrap.jl](https://github.com/JuliaInterop/CxxWrap.jl) README for more info on the API.
 


### PR DESCRIPTION
The corresponding bug has been fixed a while ago. I don't think it's necessary to add a note like "if you see this message, update your version of Julia", because it's been fixed so long ago.