### PR TITLE
Fix type hash map

### DIFF
--- a/include/jlcxx/jlcxx_config.hpp
+++ b/include/jlcxx/jlcxx_config.hpp
@@ -14,7 +14,7 @@
 #endif
 
 #define JLCXX_VERSION_MAJOR 0
-#define JLCXX_VERSION_MINOR 10
+#define JLCXX_VERSION_MINOR 11
 #define JLCXX_VERSION_PATCH 0
 
 // From https://stackoverflow.com/questions/5459868/concatenate-int-to-string-using-c-preprocessor

--- a/src/jlcxx.cpp
+++ b/src/jlcxx.cpp
@@ -341,9 +341,9 @@ namespace detail
   };
 }
 
-JLCXX_API std::map<type_hash_t, CachedDatatype>& jlcxx_type_map()
+JLCXX_API std::unordered_map<type_hash_t, CachedDatatype>& jlcxx_type_map()
 {
-  static std::map<type_hash_t, CachedDatatype> m_map;
+  static std::unordered_map<type_hash_t, CachedDatatype> m_map;
   return m_map;
 }
 


### PR DESCRIPTION
Fixes a rare error where type hashes collide, which was due to an incorrect method for creating a key out of `std::type_info`.