### PR TITLE
julia 1.11: add some workarounds for jl_array changes

### DIFF
--- a/include/jlcxx/array.hpp
+++ b/include/jlcxx/array.hpp
@@ -131,12 +131,8 @@ public:
   void push_back(VT&& val)
   {
     JL_GC_PUSH1(&m_array);
-    const size_t pos = jl_array_len(m_array);
-    jl_array_grow_end(m_array, 1);
-    jl_value_t** data = jlcxx_array_data<jl_value_t*>(m_array);
     jl_value_t* jval = box<ValueT>(val);
-    data[pos] = jval;
-    jl_gc_wb(m_array, jval);
+    jl_array_ptr_1d_push(m_array, jval);
     JL_GC_POP();
   }
 


### PR DESCRIPTION
for the changes in https://github.com/JuliaLang/julia/pull/51319

cc: @fingolfin 

_Edit:_ The library seems to build but a test module fails with:
```
[ 87%] Linking CXX executable test_module
cd /home/runner/work/libcxxwrap-julia/libcxxwrap-julia/build/test && /usr/local/bin/cmake -E cmake_link_script CMakeFiles/test_module.dir/link.txt --verbose=1
/usr/bin/c++  -Wunused-parameter -Wextra -Wreorder -fPIC -g CMakeFiles/test_module.dir/test_module.cpp.o -o test_module   -L/opt/hostedtoolcache/julia/nightly/x64/lib  -L/opt/hostedtoolcache/julia/nightly/x64/lib/julia  -Wl,-rpath,/opt/hostedtoolcache/julia/nightly/x64/lib:/opt/hostedtoolcache/julia/nightly/x64/lib/julia:/home/runner/work/libcxxwrap-julia/libcxxwrap-julia/build/lib ../lib/libcxxwrap_julia.so.0.11.1 /opt/hostedtoolcache/julia/nightly/x64/lib/libjulia.so.1.11 
/usr/bin/ld: CMakeFiles/test_module.dir/test_module.cpp.o: in function `jl_datatype_layout':
/opt/hostedtoolcache/julia/nightly/x64/include/julia/julia.h:1310: undefined reference to `jl_unwrap_unionall'
```
~Not yet sure what to make of this.~ This might be fixed by https://github.com/JuliaLang/julia/pull/51916.