### PR TITLE
Array: use jl_array_ptr_set to avoid failed assertion on nightly

### DIFF
--- a/include/jlcxx/array.hpp
+++ b/include/jlcxx/array.hpp
@@ -131,8 +131,10 @@ public:
   void push_back(VT&& val)
   {
     JL_GC_PUSH1(&m_array);
+    const size_t pos = jl_array_len(m_array);
+    jl_array_grow_end(m_array, 1);
     jl_value_t* jval = box<ValueT>(val);
-    jl_array_ptr_1d_push(m_array, jval);
+    jl_array_ptr_set(m_array, pos, jval);
     JL_GC_POP();
   }
 


### PR DESCRIPTION
My fix from #137 unfortunately triggers an assertion in [PkgEval](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2023-12/15/CxxWrap.primary.log) (i.e. nightly built with assertions enabled):
```
Failed to precompile CxxWrap [1f15a43c-97ca-5a2a-ae31-89f07a497df4] to "/home/pkgeval/.julia/compiled/v1.11/CxxWrap/jl_g65kMF".
julia: /source/src/array.c:277: ijl_array_ptr_1d_push: Assertion `(((((jl_taggedvalue_t*)((char*)(a) - sizeof(jl_taggedvalue_t)))->header) & ~(uintptr_t)15)==(uintptr_t)(jl_array_any_type))' failed.
```
(The code does seem to work fine without assertions)

Switching to `jl_array_ptr_set` avoids that error and should also work across all supported julia versions.