### PR TITLE
Make range support conditional

### DIFF
--- a/.github/workflows/test-linux-mac.yml
+++ b/.github/workflows/test-linux-mac.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           package="$(echo "$body" | sed -n '1p')"
           if [ -z "${package}" ]; then
-            package="CxxWrap"
+            package="https://github.com/JuliaInterop/CxxWrap.jl.git"
           fi
           if [[ "$OSTYPE" != "darwin"* ]]; then
             rm -f /opt/hostedtoolcache/julia/1.6*/x64/lib/julia/libstdc++.so.6

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -41,7 +41,7 @@ jobs:
           cmake -G "Visual Studio 17 2022" -A x64 -DOVERRIDES_PATH=$HOMEDRIVE/$HOMEPATH/.julia/artifacts/Overrides.toml -DOVERRIDE_ROOT=./ -DAPPEND_OVERRIDES_TOML=ON ..
           package="$(echo "$body" | sed -n '1p')"
           if [ -z "${package}" ]; then
-            package="CxxWrap"
+            package="https://github.com/JuliaInterop/CxxWrap.jl.git"
           fi
           cmake --build . --config Release
           julia -e "using Pkg; Pkg.Registry.add(\"General\"); Pkg.Registry.add(RegistrySpec(url = \"https://github.com/barche/CxxWrapTestRegistry.git\"))"

--- a/include/jlcxx/jlcxx_config.hpp
+++ b/include/jlcxx/jlcxx_config.hpp
@@ -22,4 +22,10 @@
 #define __JLCXX_STR(x) __JLCXX_STR_HELPER(x)
 #define JLCXX_VERSION_STRING __JLCXX_STR(JLCXX_VERSION_MAJOR) "." __JLCXX_STR(JLCXX_VERSION_MINOR) "." __JLCXX_STR(JLCXX_VERSION_PATCH)
 
+#if defined __has_include
+#  if __has_include (<ranges>)
+#    define JLCXX_HAS_RANGES
+#  endif
+#endif
+
 #endif

--- a/include/jlcxx/stl.hpp
+++ b/include/jlcxx/stl.hpp
@@ -77,11 +77,13 @@ using stltypes = remove_duplicates<combine_parameterlists<combine_parameterlists
 template<typename TypeWrapperT>
 void wrap_range_based_algorithms(TypeWrapperT& wrapped)
 {
+#ifdef JLCXX_HAS_RANGES
   using WrappedT = typename TypeWrapperT::type;
   using T = typename WrappedT::value_type;
   wrapped.module().set_override_module(StlWrappers::instance().module());
   wrapped.method("StdFill", [] (WrappedT& v, const T& val) { std::ranges::fill(v, val); });
   wrapped.module().unset_override_module();
+#endif
 }
 
 template<typename T>

--- a/src/stl.cpp
+++ b/src/stl.cpp
@@ -65,6 +65,9 @@ void wrap_string(TypeWrapper<string_t>&& wrapper)
 
 JLCXX_MODULE define_cxxwrap_stl_module(jlcxx::Module& stl)
 {
+#ifdef JLCXX_HAS_RANGES
+  stl.set_const("HAS_RANGES", 1);
+#endif
   jlcxx::stl::wrap_string(stl.add_type<std::string>("StdString", julia_type("CppBasicString")));
   jlcxx::stl::wrap_string(stl.add_type<std::wstring>("StdWString", julia_type("CppBasicString")));
 


### PR DESCRIPTION
@PraneethJain This is to prevent too many complications when building a JLL for macOS, we would require to impose a minimum compatibility of macOS 13, which is a bit much at the moment. On the Julia side only a change in the test is needed, see https://github.com/JuliaInterop/CxxWrap.jl/pull/428