### PR TITLE
feat: unordered set types

### DIFF
--- a/.github/workflows/test-linux-mac.yml
+++ b/.github/workflows/test-linux-mac.yml
@@ -23,6 +23,13 @@ jobs:
           - macos-13
         arch:
           - x64
+        include:
+          - os: macos-14
+            arch: aarch64
+            version: "1.10"
+          - os: macos-14
+            arch: aarch64
+            version: "nightly"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,8 @@ set(JLCXX_STL_SOURCES
     ${JLCXX_SOURCE_DIR}/stl_queue.cpp
     ${JLCXX_SOURCE_DIR}/stl_set.cpp
     ${JLCXX_SOURCE_DIR}/stl_multiset.cpp
+    ${JLCXX_SOURCE_DIR}/stl_unordered_set.cpp
+    ${JLCXX_SOURCE_DIR}/stl_unordered_multiset.cpp
     ${JLCXX_SOURCE_DIR}/stl_shared_ptr.cpp
     ${JLCXX_SOURCE_DIR}/stl_unique_ptr.cpp
     ${JLCXX_SOURCE_DIR}/stl_weak_ptr.cpp

--- a/src/stl.cpp
+++ b/src/stl.cpp
@@ -23,6 +23,8 @@ JLCXX_API void StlWrappers::instantiate(Module& mod)
   apply_queue(m_instance->queue);
   apply_set(m_instance->set);
   apply_multiset(m_instance->multiset);
+  apply_unordered_set(m_instance->unordered_set);
+  apply_unordered_multiset(m_instance->unordered_multiset);
   apply_shared_ptr();
   apply_weak_ptr();
   apply_unique_ptr();
@@ -49,7 +51,9 @@ JLCXX_API StlWrappers::StlWrappers(Module& stl) :
   deque(stl.add_type<Parametric<TypeVar<1>>>("StdDeque", julia_type("AbstractVector"))),
   queue(stl.add_type<Parametric<TypeVar<1>>>("StdQueue", julia_type("AbstractVector"))),
   set(stl.add_type<Parametric<TypeVar<1>>>("StdSet")),
-  multiset(stl.add_type<Parametric<TypeVar<1>>>("StdMultiset"))
+  multiset(stl.add_type<Parametric<TypeVar<1>>>("StdMultiset")),
+  unordered_set(stl.add_type<Parametric<TypeVar<1>>>("StdUnorderedSet")),
+  unordered_multiset(stl.add_type<Parametric<TypeVar<1>>>("StdUnorderedMultiset"))
 {
 }
 

--- a/src/stl_multiset.cpp
+++ b/src/stl_multiset.cpp
@@ -8,7 +8,7 @@ namespace stl
 
 void apply_multiset(TypeWrapper1& multiset)
 {
-  multiset.apply_combination<std::multiset, stltypes>(stl::WrapMultiset());
+  multiset.apply_combination<std::multiset, stltypes>(stl::WrapMultisetType());
 }
 
 }

--- a/src/stl_set.cpp
+++ b/src/stl_set.cpp
@@ -8,7 +8,7 @@ namespace stl
 
 void apply_set(TypeWrapper1& set)
 {
-  set.apply_combination<std::set, stltypes>(stl::WrapSet());
+  set.apply_combination<std::set, stltypes>(stl::WrapSetType());
 }
 
 }

--- a/src/stl_unordered_multiset.cpp
+++ b/src/stl_unordered_multiset.cpp
@@ -1,0 +1,16 @@
+#include "jlcxx/stl.hpp"
+
+namespace jlcxx
+{
+
+namespace stl
+{
+
+void apply_unordered_multiset(TypeWrapper1& unordered_multiset)
+{
+  unordered_multiset.apply_combination<std::unordered_multiset, stltypes>(stl::WrapMultisetType());
+}
+
+}
+
+}

--- a/src/stl_unordered_set.cpp
+++ b/src/stl_unordered_set.cpp
@@ -1,0 +1,16 @@
+#include "jlcxx/stl.hpp"
+
+namespace jlcxx
+{
+
+namespace stl
+{
+
+void apply_unordered_set(TypeWrapper1& unordered_set)
+{
+  unordered_set.apply_combination<std::unordered_set, stltypes>(stl::WrapSetType());
+}
+
+}
+
+}


### PR DESCRIPTION
https://github.com/PraneethJain/CxxWrap.jl#StdUnorderedSet

Add support for `std::unordered_set` and `std::unordered_multiset`

I've used the same wrappers as the ordered set types because they expose the same set functions.