### PR TITLE
fix: check if std::pair has less than

### DIFF
--- a/include/jlcxx/jlcxx_config.hpp
+++ b/include/jlcxx/jlcxx_config.hpp
@@ -16,14 +16,14 @@
 
 #define JLCXX_VERSION_MAJOR 0
 #define JLCXX_VERSION_MINOR 13
-#define JLCXX_VERSION_PATCH 0
+#define JLCXX_VERSION_PATCH 2
 
 // From https://stackoverflow.com/questions/5459868/concatenate-int-to-string-using-c-preprocessor
 #define __JLCXX_STR_HELPER(x) #x
 #define __JLCXX_STR(x) __JLCXX_STR_HELPER(x)
 #define JLCXX_VERSION_STRING __JLCXX_STR(JLCXX_VERSION_MAJOR) "." __JLCXX_STR(JLCXX_VERSION_MINOR) "." __JLCXX_STR(JLCXX_VERSION_PATCH)
 
-#if defined(__has_include) && !defined(__FreeBSD__)
+#if defined(__has_include) && !defined(__FreeBSD__) && !defined(JLCXX_FORCE_RANGES_OFF)
 #  if __has_include (<ranges>)
 #    define JLCXX_HAS_RANGES
 #  endif

--- a/include/jlcxx/stl.hpp
+++ b/include/jlcxx/stl.hpp
@@ -95,7 +95,7 @@ using stltypes = remove_duplicates<combine_parameterlists<combine_parameterlists
 >, fundamental_int_types>, fixed_int_types>>;
 
 template<typename TypeWrapperT>
-void wrap_range_based_algorithms(TypeWrapperT& wrapped)
+void wrap_range_based_algorithms([[maybe_unused]] TypeWrapperT& wrapped)
 {
 #ifdef JLCXX_HAS_RANGES
   using WrappedT = typename TypeWrapperT::type;

--- a/include/jlcxx/stl.hpp
+++ b/include/jlcxx/stl.hpp
@@ -312,18 +312,31 @@ template <typename T>
 struct is_container<T, std::void_t<typename T::value_type>> : std::true_type {};
 
 template <typename T, typename = void>
+struct is_pair : std::false_type {};
+
+template <typename T>
+struct is_pair<T, std::void_t<typename T::first_type, typename T::second_type>> : std::true_type {};
+
+template <typename T, typename = void>
 struct container_has_less_than_operator : std::false_type {};
 
 template <typename T>
 struct container_has_less_than_operator<T, std::enable_if_t<is_container<T>::value>>
     : std::conditional_t<
-          has_less_than_operator<typename T::value_type>::value || 
           container_has_less_than_operator<typename T::value_type>::value,
-          std::true_type, 
+          std::true_type,
           std::false_type> {};
 
 template <typename T>
-struct container_has_less_than_operator<T, std::enable_if_t<!is_container<T>::value>>
+struct container_has_less_than_operator<T, std::enable_if_t<is_pair<T>::value>>
+    : std::conditional_t<
+          container_has_less_than_operator<typename T::first_type>::value &&
+              container_has_less_than_operator<typename T::second_type>::value,
+          std::true_type,
+          std::false_type> {};
+
+template <typename T>
+struct container_has_less_than_operator<T, std::enable_if_t<!is_container<T>::value && !is_pair<T>::value>>
     : has_less_than_operator<T> {};
 
 template <typename T, typename = void>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,8 @@
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
 add_executable(test_module test_module.cpp)
-target_link_libraries(test_module ${JLCXX_TARGET} ${Julia_LIBRARY})
+set_property(TARGET test_module PROPERTY COMPILE_FLAGS "-std=c++17")
+target_link_libraries(test_module ${JLCXX_TARGET} ${JLCXX_STL_TARGET} ${Julia_LIBRARY})
 add_test(NAME test_module COMMAND test_module)
 
 add_executable(test_type_init test_type_init.cpp)

--- a/test/test_module.cpp
+++ b/test/test_module.cpp
@@ -44,6 +44,8 @@ JLCXX_MODULE register_test_module(jlcxx::Module& mod)
   mod.add_type<Foo>("Foo")
     .method("getx", &Foo::getx);
 
+  mod.add_type<std::pair<int,Foo>>("FooPair");
+
   mod.method("vectortest", [] (std::vector<Foo>) {});
   mod.method("pairtest", [] (std::vector<std::pair<int,Foo>>) {});
 

--- a/test/test_module.cpp
+++ b/test/test_module.cpp
@@ -1,5 +1,7 @@
+#define JLCXX_FORCE_RANGES_OFF
 #include <jlcxx/jlcxx.hpp>
 #include <jlcxx/functions.hpp>
+#include <jlcxx/stl.hpp>
 
 namespace test_module
 {
@@ -41,6 +43,9 @@ JLCXX_MODULE register_test_module(jlcxx::Module& mod)
 
   mod.add_type<Foo>("Foo")
     .method("getx", &Foo::getx);
+
+  mod.method("vectortest", [] (std::vector<Foo>) {});
+  mod.method("pairtest", [] (std::vector<std::pair<int,Foo>>) {});
 
   using namespace jlcxx;
 


### PR DESCRIPTION
https://github.com/JuliaInterop/CxxWrap.jl#main

`std::pair` directly has a `operator<` before c++20, and since it is not treated as a container, `std::set` was being applied to incompatible types. The tests weren't failing here because since c++20 `<=>` is used to synthesize `operator<`  (https://en.cppreference.com/w/cpp/utility/pair/operator_cmp)
 
 Because of this, inconsistent behavior was being observed
 https://pastebin.ai/0stwtqgvry
 The above program outputs different values for c++17 and c++20
 
 This PR fixes this issue by explicitly checking if the pair types are comparable.