### PR TITLE
Add `std::stack` and fix `std::queue` methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ set(JLCXX_STL_SOURCES
     ${JLCXX_SOURCE_DIR}/stl_deque.cpp
     ${JLCXX_SOURCE_DIR}/stl_queue.cpp
     ${JLCXX_SOURCE_DIR}/stl_priority_queue.cpp
+    ${JLCXX_SOURCE_DIR}/stl_stack.cpp
     ${JLCXX_SOURCE_DIR}/stl_set.cpp
     ${JLCXX_SOURCE_DIR}/stl_multiset.cpp
     ${JLCXX_SOURCE_DIR}/stl_unordered_set.cpp

--- a/include/jlcxx/stl.hpp
+++ b/include/jlcxx/stl.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <deque>
 #include <queue>
+#include <stack>
 #include <set>
 #include <unordered_set>
 
@@ -53,6 +54,7 @@ public:
   TypeWrapper1 deque;
   TypeWrapper1 queue;
   TypeWrapper1 priority_queue;
+  TypeWrapper1 stack;
   TypeWrapper1 set;
   TypeWrapper1 multiset;
   TypeWrapper1 unordered_set;
@@ -73,6 +75,7 @@ void apply_valarray(TypeWrapper1& valarray);
 void apply_deque(TypeWrapper1& deque);
 void apply_queue(TypeWrapper1& queue);
 void apply_priority_queue(TypeWrapper1& priority_queue);
+void apply_stack(TypeWrapper1& stack);
 void apply_set(TypeWrapper1& set);
 void apply_multiset(TypeWrapper1& multiset);
 void apply_unordered_set(TypeWrapper1& unordered_set);
@@ -284,6 +287,25 @@ struct WrapPriorityQueue
   }
 };
 
+struct WrapStack
+{
+  template<typename TypeWrapperT>
+  void operator()(TypeWrapperT&& wrapped)
+  {
+    using WrappedT = typename TypeWrapperT::type;
+    using T = typename WrappedT::value_type;
+
+    wrapped.template constructor<>();
+    wrapped.module().set_override_module(StlWrappers::instance().module());
+    wrapped.method("cppsize", &WrappedT::size);
+    wrapped.method("stack_isempty", [] (WrappedT& v) { return v.empty(); });
+    wrapped.method("stack_push!", [] (WrappedT& v, const T& val) { v.push(val); });
+    wrapped.method("stack_top", [] (WrappedT& v) { return v.top(); });
+    wrapped.method("stack_pop!", [] (WrappedT& v) { v.pop(); });
+    wrapped.module().unset_override_module();
+  }
+};
+
 struct WrapSetType
 {
   template<typename TypeWrapperT>
@@ -382,6 +404,7 @@ inline void apply_stl(jlcxx::Module& mod)
   TypeWrapper1(mod, StlWrappers::instance().valarray).apply<std::valarray<T>>(WrapValArray());
   TypeWrapper1(mod, StlWrappers::instance().deque).apply<std::deque<T>>(WrapDeque());
   TypeWrapper1(mod, StlWrappers::instance().queue).apply<std::queue<T>>(WrapQueue());
+  TypeWrapper1(mod, StlWrappers::instance().stack).apply<std::stack<T>>(WrapStack());
   if constexpr (container_has_less_than_operator<T>::value)
   {
     TypeWrapper1(mod, StlWrappers::instance().set).apply<std::set<T>>(WrapSetType());

--- a/include/jlcxx/stl.hpp
+++ b/include/jlcxx/stl.hpp
@@ -221,6 +221,7 @@ struct WrapQueueImpl
     
     wrapped.module().set_override_module(StlWrappers::instance().module());
     wrapped.method("cppsize", &WrappedT::size);
+    wrapped.method("q_empty", [] (WrappedT& v) { return v.empty(); });
     wrapped.method("push_back!", [] (WrappedT& v, const T& val) { v.push(val); });
     wrapped.method("front", [] (WrappedT& v) { return v.front(); });
     wrapped.method("pop_front!", [] (WrappedT& v) { v.pop(); });
@@ -238,6 +239,7 @@ struct WrapQueueImpl<bool>
 
     wrapped.module().set_override_module(StlWrappers::instance().module());
     wrapped.method("cppsize", &WrappedT::size);
+    wrapped.method("q_empty", [] (WrappedT& v) { return v.empty(); });
     wrapped.method("push_back!", [] (WrappedT& v, const bool val) { v.push(val); });
     wrapped.method("front", [] (WrappedT& v) -> bool { return v.front(); });
     wrapped.method("pop_front!", [] (WrappedT& v) { v.pop(); });

--- a/src/stl.cpp
+++ b/src/stl.cpp
@@ -22,6 +22,7 @@ JLCXX_API void StlWrappers::instantiate(Module& mod)
   apply_deque(m_instance->deque);
   apply_queue(m_instance->queue);
   apply_priority_queue(m_instance->priority_queue);
+  apply_stack(m_instance->stack);
   apply_set(m_instance->set);
   apply_multiset(m_instance->multiset);
   apply_unordered_set(m_instance->unordered_set);
@@ -53,6 +54,7 @@ JLCXX_API StlWrappers::StlWrappers(Module& stl) :
   // Assign appropriate parent types after iterators are implemented
   queue(stl.add_type<Parametric<TypeVar<1>>>("StdQueue")),
   priority_queue(stl.add_type<Parametric<TypeVar<1>>>("StdPriorityQueue")),
+  stack(stl.add_type<Parametric<TypeVar<1>>>("StdStack")),
   set(stl.add_type<Parametric<TypeVar<1>>>("StdSet")),
   multiset(stl.add_type<Parametric<TypeVar<1>>>("StdMultiset")),
   unordered_set(stl.add_type<Parametric<TypeVar<1>>>("StdUnorderedSet")),

--- a/src/stl.cpp
+++ b/src/stl.cpp
@@ -50,7 +50,8 @@ JLCXX_API StlWrappers::StlWrappers(Module& stl) :
   vector(stl.add_type<Parametric<TypeVar<1>>>("StdVector", julia_type("AbstractVector"))),
   valarray(stl.add_type<Parametric<TypeVar<1>>>("StdValArray", julia_type("AbstractVector"))),
   deque(stl.add_type<Parametric<TypeVar<1>>>("StdDeque", julia_type("AbstractVector"))),
-  queue(stl.add_type<Parametric<TypeVar<1>>>("StdQueue", julia_type("AbstractVector"))),
+  // Assign appropriate parent types after iterators are implemented
+  queue(stl.add_type<Parametric<TypeVar<1>>>("StdQueue")),
   priority_queue(stl.add_type<Parametric<TypeVar<1>>>("StdPriorityQueue")),
   set(stl.add_type<Parametric<TypeVar<1>>>("StdSet")),
   multiset(stl.add_type<Parametric<TypeVar<1>>>("StdMultiset")),

--- a/src/stl_stack.cpp
+++ b/src/stl_stack.cpp
@@ -1,0 +1,16 @@
+#include "jlcxx/stl.hpp"
+
+namespace jlcxx
+{
+
+namespace stl
+{
+
+void apply_stack(TypeWrapper1& stack)
+{
+  stack.apply_combination<std::stack, stltypes>(stl::WrapStack());
+}
+
+}
+
+}


### PR DESCRIPTION
https://github.com/PraneethJain/CxxWrap.jl#linear-containers

- Removed `AbstractVector` as parent type for `StdQueue`. This was causing errors when printing a queue, because it expects `Base.iterate` for the queue to be implemented, which hasn't been done as of now .
- Added `std::stack` support