### PR TITLE
Make application of STL wrappers more fine grained

### DIFF
--- a/.github/workflows/test-linux-mac.yml
+++ b/.github/workflows/test-linux-mac.yml
@@ -50,7 +50,7 @@ jobs:
             rm -f /opt/hostedtoolcache/julia/1.6*/x64/lib/julia/libstdc++.so.6
           fi
           mkdir build && cd build
-          cmake -DCMAKE_INSTALL_PREFIX=$HOME/install -DAPPEND_OVERRIDES_TOML=ON -DCMAKE_BUILD_TYPE=Debug ..
+          CXXFLAGS=-ftemplate-backtrace-limit=0 cmake -DCMAKE_INSTALL_PREFIX=$HOME/install -DAPPEND_OVERRIDES_TOML=ON -DCMAKE_BUILD_TYPE=Debug ..
           VERBOSE=ON cmake --build . --config Debug --target install
           wget https://github.com/JuliaBinaryWrappers/libcxxwrap_julia_jll.jl/raw/main/Project.toml
           jllversion=$(grep "version" Project.toml | sed -r 's/.* = "(.*)\+.*/\1/')

--- a/examples/types.cpp
+++ b/examples/types.cpp
@@ -448,6 +448,9 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& types)
   types.method("get_custom_nb_deletes", [] () { return UseCustomDelete::nb_deleted; });
   types.add_type<UseCustomClassDelete>("UseCustomClassDelete");
   types.method("get_custom_class_nb_deletes", [] () { return UseCustomClassDelete::nb_deleted; });
+
+  types.method("world_dequeue", []() { static World w; return std::deque({w}); });
+  types.method("world_list", []() { static World w; return std::list({w}); });
 }
 
 JLCXX_MODULE define_types2_module(jlcxx::Module& types2)

--- a/include/jlcxx/jlcxx_config.hpp
+++ b/include/jlcxx/jlcxx_config.hpp
@@ -23,8 +23,13 @@
 #define __JLCXX_STR(x) __JLCXX_STR_HELPER(x)
 #define JLCXX_VERSION_STRING __JLCXX_STR(JLCXX_VERSION_MAJOR) "." __JLCXX_STR(JLCXX_VERSION_MINOR) "." __JLCXX_STR(JLCXX_VERSION_PATCH)
 
-#if defined(__has_include) && !defined(__FreeBSD__) && !defined(JLCXX_FORCE_RANGES_OFF)
-#  if __has_include (<ranges>)
+// Apple Clang doesn't really support ranges fully until __cpp_lib_ranges==202207L (AppleClang 16)
+#if defined(__cpp_lib_ranges) && !defined(JLCXX_FORCE_RANGES_OFF)
+#  if defined(__clang__) && defined(__apple_build_version__)
+#    if __cpp_lib_ranges >= 202207L
+#      define JLCXX_HAS_RANGES
+#    endif
+#  elif __cpp_lib_ranges >= 201911L
 #    define JLCXX_HAS_RANGES
 #  endif
 #endif

--- a/include/jlcxx/jlcxx_config.hpp
+++ b/include/jlcxx/jlcxx_config.hpp
@@ -15,8 +15,8 @@
 #endif
 
 #define JLCXX_VERSION_MAJOR 0
-#define JLCXX_VERSION_MINOR 13
-#define JLCXX_VERSION_PATCH 2
+#define JLCXX_VERSION_MINOR 14
+#define JLCXX_VERSION_PATCH 0
 
 // From https://stackoverflow.com/questions/5459868/concatenate-int-to-string-using-c-preprocessor
 #define __JLCXX_STR_HELPER(x) #x

--- a/include/jlcxx/stl.hpp
+++ b/include/jlcxx/stl.hpp
@@ -50,9 +50,9 @@ namespace stl
 
 JLCXX_API jl_module_t* stl_module();
 
-void set_wrapper(Module& stl, std::string name, jl_value_t* supertype);
-TypeWrapper1& get_wrapper(std::string name);
-bool has_wrapper(std::string name);
+JLCXX_API  void set_wrapper(Module& stl, std::string name, jl_value_t* supertype);
+JLCXX_API  TypeWrapper1& get_wrapper(std::string name);
+JLCXX_API  bool has_wrapper(std::string name);
 
 // Separate per-container functions to split up the compilation over multiple C++ files
 void apply_vector();

--- a/include/jlcxx/stl.hpp
+++ b/include/jlcxx/stl.hpp
@@ -16,6 +16,10 @@
 #include "smart_pointers.hpp"
 #include "type_conversion.hpp"
 
+#ifdef JLCXX_HAS_RANGES
+#include <ranges>
+#endif
+
 namespace jlcxx
 {
 
@@ -44,67 +48,28 @@ template<typename T1, typename T2> using skip_if_same = typename SkipIfSameAs<T1
 namespace stl
 {
 
-class JLCXX_API StlWrappers
-{
-private:
-  StlWrappers(Module& mod);
-  static std::unique_ptr<StlWrappers> m_instance;
-  Module& m_stl_mod;
-public:
-  TypeWrapper1 vector;
-  TypeWrapper1 valarray;
-  TypeWrapper1 deque_iterator;
-  TypeWrapper1 deque;
-  TypeWrapper1 queue;
-  TypeWrapper1 priority_queue;
-  TypeWrapper1 stack;
-  TypeWrapper1 set_iterator;
-  TypeWrapper1 set;
-  TypeWrapper1 multiset_iterator;
-  TypeWrapper1 multiset;
-  TypeWrapper1 unordered_set_iterator;
-  TypeWrapper1 unordered_set;
-  TypeWrapper1 unordered_multiset_iterator;
-  TypeWrapper1 unordered_multiset;
-  TypeWrapper1 list_iterator;
-  TypeWrapper1 list;
-  TypeWrapper1 forward_list_iterator;
-  TypeWrapper1 forward_list;
+JLCXX_API jl_module_t* stl_module();
 
-  static void instantiate(Module& mod);
-  static StlWrappers& instance();
-
-  inline jl_module_t* module() const
-  {
-    return m_stl_mod.julia_module();
-  }
-};
+void set_wrapper(Module& stl, std::string name, jl_value_t* supertype);
+TypeWrapper1& get_wrapper(std::string name);
+bool has_wrapper(std::string name);
 
 // Separate per-container functions to split up the compilation over multiple C++ files
-void apply_vector(TypeWrapper1& vector);
-void apply_valarray(TypeWrapper1& valarray);
-void apply_deque_iterator(TypeWrapper1& deque_iterator);
-void apply_deque(TypeWrapper1& deque);
-void apply_queue(TypeWrapper1& queue);
-void apply_priority_queue(TypeWrapper1& priority_queue);
-void apply_stack(TypeWrapper1& stack);
-void apply_set_iterator(TypeWrapper1& set_iterator);
-void apply_set(TypeWrapper1& set);
-void apply_multiset_iterator(TypeWrapper1& multiset_iterator);
-void apply_multiset(TypeWrapper1& multiset);
-void apply_unordered_set_iterator(TypeWrapper1& unordered_set_iterator);
-void apply_unordered_set(TypeWrapper1& unordered_set);
-void apply_unordered_multiset_iterator(TypeWrapper1& unordered_multiset_iterator);
-void apply_unordered_multiset(TypeWrapper1& unordered_multiset);
-void apply_list_iterator(TypeWrapper1& list_iterator);
-void apply_list(TypeWrapper1& list);
-void apply_forward_list_iterator(TypeWrapper1& forward_list_iterator);
-void apply_forward_list(TypeWrapper1& forward_list);
+void apply_vector();
+void apply_valarray();
+void apply_deque();
+void apply_queue();
+void apply_priority_queue();
+void apply_stack();
+void apply_set();
+void apply_multiset();
+void apply_unordered_set();
+void apply_unordered_multiset();
+void apply_list();
+void apply_forward_list();
 void apply_shared_ptr();
 void apply_weak_ptr();
 void apply_unique_ptr();
-
-JLCXX_API StlWrappers& wrappers();
 
 using stltypes = remove_duplicates<combine_parameterlists<combine_parameterlists<ParameterList
 <
@@ -119,67 +84,24 @@ using stltypes = remove_duplicates<combine_parameterlists<combine_parameterlists
   jl_value_t*
 >, fundamental_int_types>, fixed_int_types>>;
 
-template <typename T, typename = void>
-struct has_less_than_operator : std::false_type {};
-
-template <typename T>
-struct has_less_than_operator<T, std::void_t<decltype(std::declval<T>() < std::declval<T>())>>
-    : std::true_type {};
-
-template <typename T>
-constexpr bool has_less_than_operator_v = has_less_than_operator<T>::value;
-
-template <typename T, typename = void>
-struct is_container : std::false_type {};
-
-template <typename T>
-struct is_container<T, std::void_t<typename T::value_type>> : std::true_type {};
-
-template <typename T, typename = void>
-struct is_pair : std::false_type {};
-
-template <typename T>
-struct is_pair<T, std::void_t<typename T::first_type, typename T::second_type>> : std::true_type {};
-
-template <typename T, typename = void>
-struct container_has_less_than_operator : std::false_type {};
-
-template <typename T>
-struct container_has_less_than_operator<T, std::enable_if_t<is_container<T>::value>>
-    : std::conditional_t<
-          container_has_less_than_operator<typename T::value_type>::value,
-          std::true_type,
-          std::false_type> {};
-
-template <typename T>
-struct container_has_less_than_operator<T, std::enable_if_t<is_pair<T>::value>>
-    : std::conditional_t<
-          container_has_less_than_operator<typename T::first_type>::value &&
-              container_has_less_than_operator<typename T::second_type>::value,
-          std::true_type,
-          std::false_type> {};
-
-template <typename T>
-struct container_has_less_than_operator<T, std::enable_if_t<!is_container<T>::value && !is_pair<T>::value>>
-    : has_less_than_operator<T> {};
-
-template <typename T, typename = void>
-struct is_hashable : std::false_type {};
-
-template <typename T>
-struct is_hashable<T, std::void_t<decltype(std::hash<T>{}(std::declval<T>()))>> : std::true_type {};
-
 template<typename TypeWrapperT>
 void wrap_range_based_fill([[maybe_unused]] TypeWrapperT& wrapped)
 {
 #ifdef JLCXX_HAS_RANGES
   using WrappedT = typename TypeWrapperT::type;
   using T = typename WrappedT::value_type;
-  wrapped.module().set_override_module(StlWrappers::instance().module());
+  wrapped.module().set_override_module(stl_module());
   wrapped.method("StdFill", [] (WrappedT& v, const T& val) { std::ranges::fill(v, val); });
   wrapped.module().unset_override_module();
 #endif
 }
+
+#ifdef JLCXX_HAS_RANGES
+
+template <typename T>
+constexpr bool has_less = std::is_invocable_v<std::ranges::less, T, T>;
+
+#endif
 
 template<typename TypeWrapperT>
 void wrap_range_based_bsearch([[maybe_unused]] TypeWrapperT& wrapped)
@@ -187,100 +109,20 @@ void wrap_range_based_bsearch([[maybe_unused]] TypeWrapperT& wrapped)
 #ifdef JLCXX_HAS_RANGES
   using WrappedT = typename TypeWrapperT::type;
   using T = typename WrappedT::value_type;
-  wrapped.module().set_override_module(StlWrappers::instance().module());
-  if constexpr (container_has_less_than_operator<T>::value)
+  if constexpr(has_less<T>)
   {
+    wrapped.module().set_override_module(stl_module());
     wrapped.method("StdBinarySearch", [] (WrappedT& v, const T& val) { return std::ranges::binary_search(v, val); });
+    wrapped.module().unset_override_module();
   }
-  wrapped.module().unset_override_module();
 #endif
 }
 
-template<typename T>
-struct WrapVectorImpl
-{
-  template<typename TypeWrapperT>
-  static void wrap(TypeWrapperT&& wrapped)
-  {
-    using WrappedT = std::vector<T>;
-    
-    wrap_range_based_bsearch(wrapped);
-    wrapped.module().set_override_module(StlWrappers::instance().module());
-    wrapped.method("push_back", static_cast<void (WrappedT::*)(const T&)>(&WrappedT::push_back));
-    wrapped.method("cxxgetindex", [] (const WrappedT& v, cxxint_t i) -> typename WrappedT::const_reference { return v[i-1]; });
-    wrapped.method("cxxgetindex", [] (WrappedT& v, cxxint_t i) -> typename WrappedT::reference { return v[i-1]; });
-    wrapped.method("cxxsetindex!", [] (WrappedT& v, const T& val, cxxint_t i) { v[i-1] = val; });
-    wrapped.module().unset_override_module();
-  }
-};
 
-template<>
-struct WrapVectorImpl<bool>
-{
-  template<typename TypeWrapperT>
-  static void wrap(TypeWrapperT&& wrapped)
-  {
-    using WrappedT = std::vector<bool>;
-
-    wrap_range_based_bsearch(wrapped);
-    wrapped.module().set_override_module(StlWrappers::instance().module());
-    wrapped.method("push_back", [] (WrappedT& v, const bool val) { v.push_back(val); });
-    wrapped.method("cxxgetindex", [] (const WrappedT& v, cxxint_t i) { return bool(v[i-1]); });
-    wrapped.method("cxxsetindex!", [] (WrappedT& v, const bool val, cxxint_t i) { v[i-1] = val; });
-    wrapped.module().unset_override_module();
-  }
-};
-
-struct WrapVector
-{
-  template<typename TypeWrapperT>
-  void operator()(TypeWrapperT&& wrapped)
-  {
-    using WrappedT = typename TypeWrapperT::type;
-    using T = typename WrappedT::value_type;
-    wrapped.module().set_override_module(StlWrappers::instance().module());
-    wrapped.method("cppsize", &WrappedT::size);
-    wrapped.method("resize", [] (WrappedT& v, const cxxint_t s) { v.resize(s); });
-    wrapped.method("append", [] (WrappedT& v, jlcxx::ArrayRef<T> arr)
-    {
-      const std::size_t addedlen = arr.size();
-      v.reserve(v.size() + addedlen);
-      for(size_t i = 0; i != addedlen; ++i)
-      {
-        v.push_back(arr[i]);
-      }
-    });
-    wrapped.module().unset_override_module();
-    WrapVectorImpl<T>::wrap(wrapped);
-  }
-};
-
-struct WrapValArray
-{
-  template<typename TypeWrapperT>
-  void operator()(TypeWrapperT&& wrapped)
-  {
-    using WrappedT = typename TypeWrapperT::type;
-    using T = typename WrappedT::value_type;
-
-    wrapped.template constructor<std::size_t>();
-    wrapped.template constructor<const T&, std::size_t>();
-    wrapped.template constructor<const T*, std::size_t>();
-    wrapped.module().set_override_module(StlWrappers::instance().module());
-    wrapped.method("cppsize", &WrappedT::size);
-    wrapped.method("resize", [] (WrappedT& v, const cxxint_t s) { v.resize(s); });
-    wrapped.method("cxxgetindex", [] (const WrappedT& v, cxxint_t i) { return v[i-1]; });
-    wrapped.method("cxxgetindex", [] (WrappedT& v, cxxint_t i) { return v[i-1]; });
-    wrapped.method("cxxsetindex!", [] (WrappedT& v, const T& val, cxxint_t i) { v[i-1] = val; });
-    wrapped.module().unset_override_module();
-  }
-};
-
-
-template <typename valueT, template <typename, typename=std::allocator<valueT>> typename ContainerT>
+template <typename ValueT, template<typename...> typename ContainerT>
 struct IteratorWrapper
 {
-  using value_type = valueT;
+  using value_type = ValueT;
   using iterator_type = typename ContainerT<value_type>::iterator;
 
   iterator_type value;
@@ -310,11 +152,195 @@ struct WrapIterator
   };
 };
 
-template <typename valueT>
-struct DequeIteratorWrapper : IteratorWrapper<valueT, std::deque> {};
+template<template<typename...> class ContainerT>
+struct WrapSTLContainer;
 
-struct WrapDeque
+namespace detail
 {
+  template<typename T>
+  struct ApplyCombination;
+
+  template<template<typename...> class ContainerT>
+  struct ApplyCombination<WrapSTLContainer<ContainerT>>
+  {
+    template<typename... TypeLists, typename WrapperT, typename FunctorT>
+    static void apply(WrapperT& wrapper, FunctorT&& ftor)
+    {
+      wrapper.template apply_combination<ContainerT, TypeLists...>(ftor);
+    }
+  };
+
+  template<typename T>
+  struct ApplyIteratorCombination;
+
+  template<template<typename...> class ContainerT>
+  struct ApplyIteratorCombination<WrapSTLContainer<ContainerT>>
+  {
+    template<typename ValueT>
+    struct IteratorWrapperType : IteratorWrapper<ValueT, ContainerT> {};
+
+    template<typename... TypeLists, typename WrapperT>
+    static void apply(WrapperT& wrapper)
+    {
+      wrapper.template apply_combination<IteratorWrapperType, TypeLists...>(WrapIterator());
+    }
+  };
+
+  template<typename T>
+  struct GetIteratorWrapperType;
+
+  template<template<typename...> class ContainerT, typename T, typename... Args>
+  struct GetIteratorWrapperType<ContainerT<T,Args...>>
+  {
+    using type = typename ApplyIteratorCombination<WrapSTLContainer<ContainerT>>::template IteratorWrapperType<T>;
+  };
+}
+
+template<typename T> using iterator_wrapper_type = typename detail::GetIteratorWrapperType<T>::type;
+
+template<typename T, bool HasIterator=false>
+struct STLTypeWrapperBase
+{
+  static std::string iterator_name() { return T::name() + "Iterator"; }
+  TypeWrapper1& wrapper(std::string name, bool isiterator = false)
+  {
+    if(!has_wrapper(name))
+    {
+      Module& stl = registry().current_module();
+      assert(stl.name() == "StdLib");
+      jl_value_t* supertype = isiterator ? (jl_value_t*)jl_any_type : (jl_value_t*)T::supertype();
+      set_wrapper(stl, name, supertype);
+    }
+    return get_wrapper(name);
+  }
+
+  TypeWrapper1& typewrapper()
+  {
+    return wrapper(T::name());
+  }
+
+  TypeWrapper1& iteratorwrapper()
+  {
+    return wrapper(iterator_name(), true);
+  }
+
+  template<typename... TypeLists>
+  void apply_combination()
+  {
+    if constexpr (has_iterator)
+    {
+      detail::ApplyIteratorCombination<T>::template apply<TypeLists...>(iteratorwrapper());
+    }
+    detail::ApplyCombination<T>::template apply<TypeLists...>(typewrapper(), *static_cast<T*>(this));
+  }
+
+  template<typename AppliedT>
+  void apply(Module& module)
+  {
+    if constexpr (has_iterator)
+    {
+      TypeWrapper1(module, iteratorwrapper()).apply<iterator_wrapper_type<AppliedT>>(WrapIterator());
+    }
+    TypeWrapper1(module, typewrapper()).apply<AppliedT>(*static_cast<T*>(this));
+  }
+
+  static constexpr bool has_iterator = HasIterator;
+};
+
+template<typename T>
+struct WrapVectorImpl
+{
+  template<typename TypeWrapperT>
+  static void wrap(TypeWrapperT&& wrapped)
+  {
+    using WrappedT = std::vector<T>;
+    
+    wrap_range_based_bsearch(wrapped);
+    wrapped.module().set_override_module(stl_module());
+    wrapped.method("push_back", static_cast<void (WrappedT::*)(const T&)>(&WrappedT::push_back));
+    wrapped.method("cxxgetindex", [] (const WrappedT& v, cxxint_t i) -> typename WrappedT::const_reference { return v[i-1]; });
+    wrapped.method("cxxgetindex", [] (WrappedT& v, cxxint_t i) -> typename WrappedT::reference { return v[i-1]; });
+    wrapped.method("cxxsetindex!", [] (WrappedT& v, const T& val, cxxint_t i) { v[i-1] = val; });
+    wrapped.module().unset_override_module();
+  }
+};
+
+template<>
+struct WrapVectorImpl<bool>
+{
+  template<typename TypeWrapperT>
+  static void wrap(TypeWrapperT&& wrapped)
+  {
+    using WrappedT = std::vector<bool>;
+
+    wrap_range_based_bsearch(wrapped);
+    wrapped.module().set_override_module(stl_module());
+    wrapped.method("push_back", [] (WrappedT& v, const bool val) { v.push_back(val); });
+    wrapped.method("cxxgetindex", [] (const WrappedT& v, cxxint_t i) { return bool(v[i-1]); });
+    wrapped.method("cxxsetindex!", [] (WrappedT& v, const bool val, cxxint_t i) { v[i-1] = val; });
+    wrapped.module().unset_override_module();
+  }
+};
+
+template<>
+struct WrapSTLContainer<std::vector> : STLTypeWrapperBase<WrapSTLContainer<std::vector>>
+{
+  static std::string name() { return "StdVector"; }
+  static jl_value_t* supertype() { return julia_type("AbstractVector"); }
+
+  template<typename TypeWrapperT>
+  void operator()(TypeWrapperT&& wrapped)
+  {
+    using WrappedT = typename TypeWrapperT::type;
+    using T = typename WrappedT::value_type;
+    wrapped.module().set_override_module(stl_module());
+    wrapped.method("cppsize", &WrappedT::size);
+    wrapped.method("resize", [] (WrappedT& v, const cxxint_t s) { v.resize(s); });
+    wrapped.method("append", [] (WrappedT& v, jlcxx::ArrayRef<T> arr)
+    {
+      const std::size_t addedlen = arr.size();
+      v.reserve(v.size() + addedlen);
+      for(size_t i = 0; i != addedlen; ++i)
+      {
+        v.push_back(arr[i]);
+      }
+    });
+    wrapped.module().unset_override_module();
+    WrapVectorImpl<T>::wrap(wrapped);
+  }
+};
+
+template<>
+struct WrapSTLContainer<std::valarray> : STLTypeWrapperBase<WrapSTLContainer<std::valarray>>
+{
+  static std::string name() { return "StdValArray"; }
+  static jl_value_t* supertype() { return julia_type("AbstractVector"); }
+
+  template<typename TypeWrapperT>
+  void operator()(TypeWrapperT&& wrapped)
+  {
+    using WrappedT = typename TypeWrapperT::type;
+    using T = typename WrappedT::value_type;
+
+    wrapped.template constructor<std::size_t>();
+    wrapped.template constructor<const T&, std::size_t>();
+    wrapped.template constructor<const T*, std::size_t>();
+    wrapped.module().set_override_module(stl_module());
+    wrapped.method("cppsize", &WrappedT::size);
+    wrapped.method("resize", [] (WrappedT& v, const cxxint_t s) { v.resize(s); });
+    wrapped.method("cxxgetindex", [] (const WrappedT& v, cxxint_t i) { return v[i-1]; });
+    wrapped.method("cxxgetindex", [] (WrappedT& v, cxxint_t i) { return v[i-1]; });
+    wrapped.method("cxxsetindex!", [] (WrappedT& v, const T& val, cxxint_t i) { v[i-1] = val; });
+    wrapped.module().unset_override_module();
+  }
+};
+
+template<>
+struct WrapSTLContainer<std::deque> : STLTypeWrapperBase<WrapSTLContainer<std::deque>,true>
+{
+  static std::string name() { return "StdDeque"; }
+  static jl_value_t* supertype() { return julia_type("AbstractVector"); }
+
   template<typename TypeWrapperT>
   void operator()(TypeWrapperT&& wrapped)
   {
@@ -323,7 +349,7 @@ struct WrapDeque
 
     wrap_range_based_bsearch(wrapped);
     wrapped.template constructor<std::size_t>();
-    wrapped.module().set_override_module(StlWrappers::instance().module());
+    wrapped.module().set_override_module(stl_module());
     wrapped.method("cppsize", &WrappedT::size);
     wrapped.method("resize", [](WrappedT &v, const cxxint_t s) { v.resize(s); });
     wrapped.method("cxxgetindex", [](const WrappedT& v, cxxint_t i) { return v[i - 1]; });
@@ -332,8 +358,8 @@ struct WrapDeque
     wrapped.method("push_front!", [] (WrappedT& v, const T& val) { v.push_front(val); });
     wrapped.method("pop_back!", [] (WrappedT& v) { v.pop_back(); });
     wrapped.method("pop_front!", [] (WrappedT& v) { v.pop_front(); });
-    wrapped.method("iteratorbegin", [] (WrappedT& v) { return DequeIteratorWrapper<T>{v.begin()}; });
-    wrapped.method("iteratorend", [] (WrappedT& v) { return DequeIteratorWrapper<T>{v.end()}; });
+    wrapped.method("iteratorbegin", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.begin()}; });
+    wrapped.method("iteratorend", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.end()}; });
     wrapped.module().unset_override_module();
   }
 };
@@ -346,7 +372,7 @@ struct WrapQueueImpl
   {
     using WrappedT = std::queue<T>;
     
-    wrapped.module().set_override_module(StlWrappers::instance().module());
+    wrapped.module().set_override_module(stl_module());
     wrapped.method("cppsize", &WrappedT::size);
     wrapped.method("q_empty", [] (WrappedT& v) { return v.empty(); });
     wrapped.method("push_back!", [] (WrappedT& v, const T& val) { v.push(val); });
@@ -364,7 +390,7 @@ struct WrapQueueImpl<bool>
   {
     using WrappedT = std::queue<bool>;
 
-    wrapped.module().set_override_module(StlWrappers::instance().module());
+    wrapped.module().set_override_module(stl_module());
     wrapped.method("cppsize", &WrappedT::size);
     wrapped.method("q_empty", [] (WrappedT& v) { return v.empty(); });
     wrapped.method("push_back!", [] (WrappedT& v, const bool val) { v.push(val); });
@@ -374,8 +400,12 @@ struct WrapQueueImpl<bool>
   }
 };
 
-struct WrapQueue
+template<>
+struct WrapSTLContainer<std::queue> : STLTypeWrapperBase<WrapSTLContainer<std::queue>,false>
 {
+  static std::string name() { return "StdQueue"; }
+  static jl_datatype_t* supertype() { return jl_any_type; }
+
   template<typename TypeWrapperT>
   void operator()(TypeWrapperT&& wrapped)
   {
@@ -385,8 +415,12 @@ struct WrapQueue
   }
 };
 
-struct WrapPriorityQueue
+template<>
+struct WrapSTLContainer<std::priority_queue> : STLTypeWrapperBase<WrapSTLContainer<std::priority_queue>,false>
 {
+  static std::string name() { return "StdPriorityQueue"; }
+  static jl_datatype_t* supertype() { return jl_any_type; }
+
   template<typename TypeWrapperT>
   void operator()(TypeWrapperT&& wrapped)
   {
@@ -394,7 +428,7 @@ struct WrapPriorityQueue
     using T = typename WrappedT::value_type;
 
     wrapped.template constructor<>();
-    wrapped.module().set_override_module(StlWrappers::instance().module());
+    wrapped.module().set_override_module(stl_module());
     wrapped.method("cppsize", &WrappedT::size);
     wrapped.method("pq_push!", [] (WrappedT& v, const T& val) { v.push(val); });
     wrapped.method("pq_pop!", [] (WrappedT& v) { v.pop(); });
@@ -411,8 +445,12 @@ struct WrapPriorityQueue
   }
 };
 
-struct WrapStack
+template<>
+struct WrapSTLContainer<std::stack> : STLTypeWrapperBase<WrapSTLContainer<std::stack>,false>
 {
+  static std::string name() { return "StdStack"; }
+  static jl_datatype_t* supertype() { return jl_any_type; }
+
   template<typename TypeWrapperT>
   void operator()(TypeWrapperT&& wrapped)
   {
@@ -420,7 +458,7 @@ struct WrapStack
     using T = typename WrappedT::value_type;
 
     wrapped.template constructor<>();
-    wrapped.module().set_override_module(StlWrappers::instance().module());
+    wrapped.module().set_override_module(stl_module());
     wrapped.method("cppsize", &WrappedT::size);
     wrapped.method("stack_isempty", [] (WrappedT& v) { return v.empty(); });
     wrapped.method("stack_push!", [] (WrappedT& v, const T& val) { v.push(val); });
@@ -430,16 +468,12 @@ struct WrapStack
   }
 };
 
-template <typename valueT>
-struct SetIteratorWrapper
+template<>
+struct WrapSTLContainer<std::set> : STLTypeWrapperBase<WrapSTLContainer<std::set>,true>
 {
-  using value_type = valueT;
-  using iterator_type = typename std::set<valueT, std::less<valueT>, std::allocator<valueT>>::iterator;
-  iterator_type value;
-};
+  static std::string name() { return "StdSet"; }
+  static jl_value_t* supertype() { return julia_type("AbstractSet"); }
 
-struct WrapSet
-{
   template<typename TypeWrapperT>
   void operator()(TypeWrapperT&& wrapped)
   {
@@ -448,41 +482,32 @@ struct WrapSet
 
     wrap_range_based_bsearch(wrapped);
     wrapped.template constructor<>();
-    wrapped.module().set_override_module(StlWrappers::instance().module());
+    wrapped.module().set_override_module(stl_module());
     wrapped.method("cppsize", &WrappedT::size);
     wrapped.method("set_insert!", [] (WrappedT& v, const T& val) { v.insert(val); });
     wrapped.method("set_empty!", [] (WrappedT& v) { v.clear(); });
     wrapped.method("set_isempty", [] (WrappedT& v) { return v.empty(); });
     wrapped.method("set_delete!", [] (WrappedT&v, const T& val) { v.erase(val); });
     wrapped.method("set_in", [] (WrappedT& v, const T& val) { return v.count(val) != 0; });
-    wrapped.method("iteratorbegin", [] (WrappedT& v) { return SetIteratorWrapper<T>{v.begin()}; });
-    wrapped.method("iteratorend", [] (WrappedT& v) { return SetIteratorWrapper<T>{v.end()}; });
+    wrapped.method("iteratorbegin", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.begin()}; });
+    wrapped.method("iteratorend", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.end()}; });
 #ifdef JLCXX_HAS_RANGES
-    if constexpr (container_has_less_than_operator<T>::value)
+    if constexpr(has_less<T>)
     {
-      wrapped.method("StdUpperBound", [] (WrappedT& v, const T& val) { return SetIteratorWrapper<T>{std::ranges::upper_bound(v, val)}; });
-      wrapped.method("StdLowerBound", [] (WrappedT& v, const T& val) { return SetIteratorWrapper<T>{std::ranges::lower_bound(v, val)}; });
+      wrapped.method("StdUpperBound", [] (WrappedT& v, const T& val) { return iterator_wrapper_type<WrappedT>{std::ranges::upper_bound(v, val)}; });
+      wrapped.method("StdLowerBound", [] (WrappedT& v, const T& val) { return iterator_wrapper_type<WrappedT>{std::ranges::lower_bound(v, val)}; });
     }
 #endif
     wrapped.module().unset_override_module();
   }
 };
 
-template <typename valueT>
-struct UnorderedSetIteratorWrapper
+template<>
+struct WrapSTLContainer<std::unordered_set> : STLTypeWrapperBase<WrapSTLContainer<std::unordered_set>,true>
 {
-  using value_type = valueT;
-  using iterator_type = typename std::unordered_set<
-      valueT,
-      std::hash<valueT>,
-      std::equal_to<valueT>,
-      std::allocator<valueT>
-  >::iterator;
-  iterator_type value;
-};
+  static std::string name() { return "StdUnorderedSet"; }
+  static jl_value_t* supertype() { return julia_type("AbstractSet"); }
 
-struct WrapUnorderedSet
-{
   template<typename TypeWrapperT>
   void operator()(TypeWrapperT&& wrapped)
   {
@@ -490,33 +515,25 @@ struct WrapUnorderedSet
     using T = typename WrappedT::value_type;
 
     wrapped.template constructor<>();
-    wrapped.module().set_override_module(StlWrappers::instance().module());
+    wrapped.module().set_override_module(stl_module());
     wrapped.method("cppsize", &WrappedT::size);
     wrapped.method("set_insert!", [] (WrappedT& v, const T& val) { v.insert(val); });
     wrapped.method("set_empty!", [] (WrappedT& v) { v.clear(); });
     wrapped.method("set_isempty", [] (WrappedT& v) { return v.empty(); });
     wrapped.method("set_delete!", [] (WrappedT&v, const T& val) { v.erase(val); });
     wrapped.method("set_in", [] (WrappedT& v, const T& val) { return v.count(val) != 0; });
-    wrapped.method("iteratorbegin", [] (WrappedT& v) { return UnorderedSetIteratorWrapper<T>{v.begin()}; });
-    wrapped.method("iteratorend", [] (WrappedT& v) { return UnorderedSetIteratorWrapper<T>{v.end()}; });
+    wrapped.method("iteratorbegin", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.begin()}; });
+    wrapped.method("iteratorend", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.end()}; });
     wrapped.module().unset_override_module();
   }
 };
 
-template <typename valueT>
-struct MultisetIteratorWrapper
+template<>
+struct WrapSTLContainer<std::multiset> : STLTypeWrapperBase<WrapSTLContainer<std::multiset>,true>
 {
-  using value_type = valueT;
-  using iterator_type = typename std::multiset<
-      valueT,
-      std::less<valueT>,
-      std::allocator<valueT>
-  >::iterator;
-  iterator_type value;
-};
+  static std::string name() { return "StdMultiset"; }
+  static jl_value_t* supertype() { return julia_type("AbstractSet"); }
 
-struct WrapMultiset
-{
   template<typename TypeWrapperT>
   void operator()(TypeWrapperT&& wrapped)
   {
@@ -525,7 +542,7 @@ struct WrapMultiset
 
     wrap_range_based_bsearch(wrapped);
     wrapped.template constructor<>();
-    wrapped.module().set_override_module(StlWrappers::instance().module());
+    wrapped.module().set_override_module(stl_module());
     wrapped.method("cppsize", &WrappedT::size);
     wrapped.method("multiset_insert!", [] (WrappedT& v, const T& val) { v.insert(val); });
     wrapped.method("multiset_empty!", [] (WrappedT& v) { v.clear(); });
@@ -533,34 +550,25 @@ struct WrapMultiset
     wrapped.method("multiset_delete!", [] (WrappedT&v, const T& val) { v.erase(val); });
     wrapped.method("multiset_in", [] (WrappedT& v, const T& val) { return v.count(val) != 0; });
     wrapped.method("multiset_count", [] (WrappedT& v, const T& val) { return v.count(val); });
-    wrapped.method("iteratorbegin", [] (WrappedT& v) { return MultisetIteratorWrapper<T>{v.begin()}; });
-    wrapped.method("iteratorend", [] (WrappedT& v) { return MultisetIteratorWrapper<T>{v.end()}; });
+    wrapped.method("iteratorbegin", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.begin()}; });
+    wrapped.method("iteratorend", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.end()}; });
 #ifdef JLCXX_HAS_RANGES
-    if constexpr (container_has_less_than_operator<T>::value)
+    if constexpr(has_less<T>)
     {
-      wrapped.method("StdUpperBound", [] (WrappedT& v, const T& val) { return MultisetIteratorWrapper<T>{std::ranges::upper_bound(v, val)}; });
-      wrapped.method("StdLowerBound", [] (WrappedT& v, const T& val) { return MultisetIteratorWrapper<T>{std::ranges::lower_bound(v, val)}; });
+      wrapped.method("StdUpperBound", [] (WrappedT& v, const T& val) { return iterator_wrapper_type<WrappedT>{std::ranges::upper_bound(v, val)}; });
+      wrapped.method("StdLowerBound", [] (WrappedT& v, const T& val) { return iterator_wrapper_type<WrappedT>{std::ranges::lower_bound(v, val)}; });
     }
 #endif
     wrapped.module().unset_override_module();
   }
 };
 
-template <typename valueT>
-struct UnorderedMultisetIteratorWrapper
+template<>
+struct WrapSTLContainer<std::unordered_multiset> : STLTypeWrapperBase<WrapSTLContainer<std::unordered_multiset>,true>
 {
-  using value_type = valueT;
-  using iterator_type = typename std::unordered_multiset<
-      valueT,
-      std::hash<valueT>,
-      std::equal_to<valueT>,
-      std::allocator<valueT>
-  >::iterator;
-  iterator_type value;
-};
+  static std::string name() { return "StdUnorderedMultiset"; }
+  static jl_value_t* supertype() { return julia_type("AbstractSet"); }
 
-struct WrapUnorderedMultiset
-{
   template<typename TypeWrapperT>
   void operator()(TypeWrapperT&& wrapped)
   {
@@ -568,7 +576,7 @@ struct WrapUnorderedMultiset
     using T = typename WrappedT::value_type;
 
     wrapped.template constructor<>();
-    wrapped.module().set_override_module(StlWrappers::instance().module());
+    wrapped.module().set_override_module(stl_module());
     wrapped.method("cppsize", &WrappedT::size);
     wrapped.method("multiset_insert!", [] (WrappedT& v, const T& val) { v.insert(val); });
     wrapped.method("multiset_empty!", [] (WrappedT& v) { v.clear(); });
@@ -576,17 +584,18 @@ struct WrapUnorderedMultiset
     wrapped.method("multiset_delete!", [] (WrappedT&v, const T& val) { v.erase(val); });
     wrapped.method("multiset_in", [] (WrappedT& v, const T& val) { return v.count(val) != 0; });
     wrapped.method("multiset_count", [] (WrappedT& v, const T& val) { return v.count(val); });
-    wrapped.method("iteratorbegin", [] (WrappedT& v) { return UnorderedMultisetIteratorWrapper<T>{v.begin()}; });
-    wrapped.method("iteratorend", [] (WrappedT& v) { return UnorderedMultisetIteratorWrapper<T>{v.end()}; });
+    wrapped.method("iteratorbegin", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.begin()}; });
+    wrapped.method("iteratorend", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.end()}; });
     wrapped.module().unset_override_module();
   }
 };
 
-template <typename valueT>
-struct ListIteratorWrapper : IteratorWrapper<valueT, std::list> {};
-
-struct WrapList
+template<>
+struct WrapSTLContainer<std::list> : STLTypeWrapperBase<WrapSTLContainer<std::list>,true>
 {
+  static std::string name() { return "StdList"; }
+  static jl_value_t* supertype() { return (jl_value_t*)jl_any_type; }
+
   template<typename TypeWrapperT>
   void operator()(TypeWrapperT&& wrapped)
   {
@@ -596,7 +605,7 @@ struct WrapList
     wrap_range_based_fill(wrapped);
     wrap_range_based_bsearch(wrapped);
     wrapped.template constructor<>();
-    wrapped.module().set_override_module(StlWrappers::instance().module());\
+    wrapped.module().set_override_module(stl_module());\
     wrapped.method("cppsize", &WrappedT::size);
     wrapped.method("list_empty!", [] (WrappedT& v) { v.clear(); });
     wrapped.method("list_isempty", [] (WrappedT& v) { return v.empty(); });
@@ -606,13 +615,13 @@ struct WrapList
     wrapped.method("list_push_front!", [] (WrappedT& v, const T& val) { v.push_front(val); });
     wrapped.method("list_pop_back!", [] (WrappedT& v) { v.pop_back(); });
     wrapped.method("list_pop_front!", [] (WrappedT& v) { v.pop_front(); });
-    wrapped.method("iteratorbegin", [] (WrappedT& v) { return ListIteratorWrapper<T>{v.begin()}; });
-    wrapped.method("iteratorend", [] (WrappedT& v) { return ListIteratorWrapper<T>{v.end()}; });
+    wrapped.method("iteratorbegin", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.begin()}; });
+    wrapped.method("iteratorend", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.end()}; });
 #ifdef JLCXX_HAS_RANGES
-    if constexpr (container_has_less_than_operator<T>::value)
+    if constexpr(has_less<T>)
     {
-      wrapped.method("StdUpperBound", [] (WrappedT& v, const T& val) { return ListIteratorWrapper<T>{std::ranges::upper_bound(v, val)}; });
-      wrapped.method("StdLowerBound", [] (WrappedT& v, const T& val) { return ListIteratorWrapper<T>{std::ranges::lower_bound(v, val)}; });
+      wrapped.method("StdUpperBound", [] (WrappedT& v, const T& val) { return iterator_wrapper_type<WrappedT>{std::ranges::upper_bound(v, val)}; });
+      wrapped.method("StdLowerBound", [] (WrappedT& v, const T& val) { return iterator_wrapper_type<WrappedT>{std::ranges::lower_bound(v, val)}; });
       wrapped.method("StdListSort", [] (WrappedT& v) { v.sort(); });
     }
 #endif
@@ -620,11 +629,12 @@ struct WrapList
   }
 };
 
-template <typename valueT>
-struct ForwardListIteratorWrapper : IteratorWrapper<valueT, std::forward_list> {};
-
-struct WrapForwardList
+template<>
+struct WrapSTLContainer<std::forward_list> : STLTypeWrapperBase<WrapSTLContainer<std::forward_list>,true>
 {
+  static std::string name() { return "StdForwardList"; }
+  static jl_value_t* supertype() { return (jl_value_t*)jl_any_type; }
+
   template<typename TypeWrapperT>
   void operator()(TypeWrapperT&& wrapped)
   {
@@ -633,54 +643,22 @@ struct WrapForwardList
 
     wrap_range_based_fill(wrapped);
     wrapped.template constructor<>();
-    wrapped.module().set_override_module(StlWrappers::instance().module());
+    wrapped.module().set_override_module(stl_module());
     wrapped.method("flist_empty!", [] (WrappedT& v) { v.clear(); });
     wrapped.method("flist_isempty", [] (WrappedT& v) { return v.empty(); });
     wrapped.method("flist_front", [] (WrappedT& v) { return v.front(); });
     wrapped.method("flist_push_front!", [] (WrappedT& v, const T& val) { v.push_front(val); });
     wrapped.method("flist_pop_front!", [] (WrappedT& v) { v.pop_front(); });
-    wrapped.method("iteratorbegin", [] (WrappedT& v) { return ForwardListIteratorWrapper<T>{v.begin()}; });
-    wrapped.method("iteratorend", [] (WrappedT& v) { return ForwardListIteratorWrapper<T>{v.end()}; });
+    wrapped.method("iteratorbegin", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.begin()}; });
+    wrapped.method("iteratorend", [] (WrappedT& v) { return iterator_wrapper_type<WrappedT>{v.end()}; });
     wrapped.module().unset_override_module();
   }
 };
 
-template<typename T>
-inline void apply_stl(jlcxx::Module& mod)
+template<template<typename...> class ContainerT, typename T, typename... Args>
+struct stl_container_type_factory
 {
-  TypeWrapper1(mod, StlWrappers::instance().vector).apply<std::vector<T>>(WrapVector());
-  TypeWrapper1(mod, StlWrappers::instance().valarray).apply<std::valarray<T>>(WrapValArray());
-  TypeWrapper1(mod, StlWrappers::instance().deque_iterator).apply<stl::DequeIteratorWrapper<T>>(WrapIterator());
-  TypeWrapper1(mod, StlWrappers::instance().deque).apply<std::deque<T>>(WrapDeque());
-  TypeWrapper1(mod, StlWrappers::instance().queue).apply<std::queue<T>>(WrapQueue());
-  TypeWrapper1(mod, StlWrappers::instance().stack).apply<std::stack<T>>(WrapStack());
-  if constexpr (container_has_less_than_operator<T>::value)
-  {
-    TypeWrapper1(mod, StlWrappers::instance().set_iterator).apply<stl::SetIteratorWrapper<T>>(WrapIterator());
-    TypeWrapper1(mod, StlWrappers::instance().set).apply<std::set<T>>(WrapSet());
-    TypeWrapper1(mod, StlWrappers::instance().multiset_iterator).apply<stl::MultisetIteratorWrapper<T>>(WrapIterator());
-    TypeWrapper1(mod, StlWrappers::instance().multiset).apply<std::multiset<T>>(WrapMultiset());
-    TypeWrapper1(mod, StlWrappers::instance().priority_queue).apply<std::priority_queue<T>>(WrapPriorityQueue());
-  }
-  if constexpr (is_hashable<T>::value)
-  {
-    TypeWrapper1(mod, StlWrappers::instance().unordered_set_iterator).apply<stl::UnorderedSetIteratorWrapper<T>>(WrapIterator());
-    TypeWrapper1(mod, StlWrappers::instance().unordered_set).apply<std::unordered_set<T>>(WrapUnorderedSet());
-    TypeWrapper1(mod, StlWrappers::instance().unordered_multiset_iterator).apply<stl::UnorderedMultisetIteratorWrapper<T>>(WrapIterator());
-    TypeWrapper1(mod, StlWrappers::instance().unordered_multiset).apply<std::unordered_multiset<T>>(WrapUnorderedMultiset());
-  }
-  TypeWrapper1(mod, StlWrappers::instance().list_iterator).apply<stl::ListIteratorWrapper<T>>(WrapIterator());
-  TypeWrapper1(mod, StlWrappers::instance().list).apply<std::list<T>>(WrapList());
-  TypeWrapper1(mod, StlWrappers::instance().forward_list_iterator).apply<stl::ForwardListIteratorWrapper<T>>(WrapIterator());
-  TypeWrapper1(mod, StlWrappers::instance().forward_list).apply<std::forward_list<T>>(WrapForwardList());
-}
-
-}
-
-template<typename T>
-struct julia_type_factory<std::vector<T>>
-{
-  using MappedT = std::vector<T>;
+  using MappedT = ContainerT<T,Args...>;
 
   static inline jl_datatype_t* julia_type()
   {
@@ -689,11 +667,27 @@ struct julia_type_factory<std::vector<T>>
     assert(registry().has_current_module());
     jl_datatype_t* jltype = ::jlcxx::julia_type<T>();
     Module& curmod = registry().current_module();
-    stl::apply_stl<T>(curmod);
+    WrapSTLContainer<ContainerT> wrap;
+    wrap.template apply<MappedT>(curmod);
     assert(has_julia_type<MappedT>());
     return stored_type<MappedT>().get_dt();
   }
 };
+
+}
+
+template<typename... Args> struct julia_type_factory<std::vector<Args...>>             : stl::stl_container_type_factory<std::vector,Args...> {};
+template<typename... Args> struct julia_type_factory<std::valarray<Args...>>           : stl::stl_container_type_factory<std::valarray,Args...> {};
+template<typename... Args> struct julia_type_factory<std::deque<Args...>>              : stl::stl_container_type_factory<std::deque,Args...> {};
+template<typename... Args> struct julia_type_factory<std::queue<Args...>>              : stl::stl_container_type_factory<std::queue,Args...> {};
+template<typename... Args> struct julia_type_factory<std::priority_queue<Args...>>     : stl::stl_container_type_factory<std::priority_queue,Args...> {};
+template<typename... Args> struct julia_type_factory<std::stack<Args...>>              : stl::stl_container_type_factory<std::stack,Args...> {};
+template<typename... Args> struct julia_type_factory<std::set<Args...>>                : stl::stl_container_type_factory<std::set,Args...> {};
+template<typename... Args> struct julia_type_factory<std::unordered_set<Args...>>      : stl::stl_container_type_factory<std::unordered_set,Args...> {};
+template<typename... Args> struct julia_type_factory<std::multiset<Args...>>           : stl::stl_container_type_factory<std::multiset,Args...> {};
+template<typename... Args> struct julia_type_factory<std::unordered_multiset<Args...>> : stl::stl_container_type_factory<std::unordered_multiset,Args...> {};
+template<typename... Args> struct julia_type_factory<std::list<Args...>>               : stl::stl_container_type_factory<std::list,Args...> {};
+template<typename... Args> struct julia_type_factory<std::forward_list<Args...>>       : stl::stl_container_type_factory<std::forward_list,Args...> {};
 
 }
 

--- a/src/stl.cpp
+++ b/src/stl.cpp
@@ -20,7 +20,7 @@ StoredWrappersT& stl_wrappers()
   return wrappers;
 }
 
-void set_wrapper(Module& stl, std::string name, jl_value_t* supertype)
+JLCXX_API void set_wrapper(Module& stl, std::string name, jl_value_t* supertype)
 {
   auto result = stl_wrappers().insert(std::make_pair(name, stl.add_type<Parametric<TypeVar<1>>>(name, supertype)));
   if(!result.second)
@@ -29,7 +29,7 @@ void set_wrapper(Module& stl, std::string name, jl_value_t* supertype)
   }
 }
 
-TypeWrapper1& get_wrapper(std::string name)
+JLCXX_API TypeWrapper1& get_wrapper(std::string name)
 {
   auto result = stl_wrappers().find(name);
   if(result == stl_wrappers().end())
@@ -39,7 +39,7 @@ TypeWrapper1& get_wrapper(std::string name)
   return result->second;
 }
 
-bool has_wrapper(std::string name)
+JLCXX_API bool has_wrapper(std::string name)
 {
   return stl_wrappers().count(name) != 0;
 }

--- a/src/stl_deque.cpp
+++ b/src/stl_deque.cpp
@@ -6,14 +6,9 @@ namespace jlcxx
 namespace stl
 {
 
-void apply_deque_iterator(TypeWrapper1& deque_iterator)
+void apply_deque()
 {
-  deque_iterator.apply_combination<stl::DequeIteratorWrapper, stltypes>(stl::WrapIterator());
-}
-
-void apply_deque(TypeWrapper1& deque)
-{
-  deque.apply_combination<std::deque, stltypes>(stl::WrapDeque());
+  WrapSTLContainer<std::deque>().apply_combination<stltypes>();
 }
 
 }

--- a/src/stl_forward_list.cpp
+++ b/src/stl_forward_list.cpp
@@ -6,14 +6,9 @@ namespace jlcxx
 namespace stl
 {
 
-void apply_forward_list_iterator(TypeWrapper1& forward_list_iterator)
+void apply_forward_list()
 {
-  forward_list_iterator.apply_combination<stl::ForwardListIteratorWrapper, stltypes>(stl::WrapIterator());
-}
-
-void apply_forward_list(TypeWrapper1& forward_list)
-{
-  forward_list.apply_combination<std::forward_list, stltypes>(stl::WrapForwardList());
+  WrapSTLContainer<std::forward_list>().apply_combination<stltypes>();
 }
 
 }

--- a/src/stl_list.cpp
+++ b/src/stl_list.cpp
@@ -6,14 +6,9 @@ namespace jlcxx
 namespace stl
 {
 
-void apply_list_iterator(TypeWrapper1& list_iterator)
+void apply_list()
 {
-  list_iterator.apply_combination<stl::ListIteratorWrapper, stltypes>(stl::WrapIterator());
-}
-
-void apply_list(TypeWrapper1& list)
-{
-  list.apply_combination<std::list, stltypes>(stl::WrapList());
+  WrapSTLContainer<std::list>().apply_combination<stltypes>();
 }
 
 }

--- a/src/stl_multiset.cpp
+++ b/src/stl_multiset.cpp
@@ -6,14 +6,9 @@ namespace jlcxx
 namespace stl
 {
 
-void apply_multiset_iterator(TypeWrapper1& multiset_iterator)
+void apply_multiset()
 {
-  multiset_iterator.apply_combination<stl::MultisetIteratorWrapper, stltypes>(stl::WrapIterator());
-}
-
-void apply_multiset(TypeWrapper1& multiset)
-{
-  multiset.apply_combination<std::multiset, stltypes>(stl::WrapMultiset());
+  WrapSTLContainer<std::multiset>().apply_combination<stltypes>();
 }
 
 }

--- a/src/stl_priority_queue.cpp
+++ b/src/stl_priority_queue.cpp
@@ -6,9 +6,9 @@ namespace jlcxx
 namespace stl
 {
 
-void apply_priority_queue(TypeWrapper1& priority_queue)
+void apply_priority_queue()
 {
-  priority_queue.apply_combination<std::priority_queue, stltypes>(stl::WrapPriorityQueue());
+  WrapSTLContainer<std::priority_queue>().apply_combination<stltypes>();
 }
 
 }

--- a/src/stl_queue.cpp
+++ b/src/stl_queue.cpp
@@ -6,9 +6,9 @@ namespace jlcxx
 namespace stl
 {
 
-void apply_queue(TypeWrapper1& queue)
+void apply_queue()
 {
-  queue.apply_combination<std::queue, stltypes>(stl::WrapQueue());
+  WrapSTLContainer<std::queue>().apply_combination<stltypes>();
 }
 
 }

--- a/src/stl_set.cpp
+++ b/src/stl_set.cpp
@@ -6,14 +6,9 @@ namespace jlcxx
 namespace stl
 {
 
-void apply_set_iterator(TypeWrapper1& set_iterator)
+void apply_set()
 {
-  set_iterator.apply_combination<stl::SetIteratorWrapper, stltypes>(stl::WrapIterator());
-}
-
-void apply_set(TypeWrapper1& set)
-{
-  set.apply_combination<std::set, stltypes>(stl::WrapSet());
+  WrapSTLContainer<std::set>().apply_combination<stltypes>();
 }
 
 }

--- a/src/stl_stack.cpp
+++ b/src/stl_stack.cpp
@@ -6,9 +6,9 @@ namespace jlcxx
 namespace stl
 {
 
-void apply_stack(TypeWrapper1& stack)
+void apply_stack()
 {
-  stack.apply_combination<std::stack, stltypes>(stl::WrapStack());
+  WrapSTLContainer<std::stack>().apply_combination<stltypes>();
 }
 
 }

--- a/src/stl_unordered_multiset.cpp
+++ b/src/stl_unordered_multiset.cpp
@@ -6,14 +6,9 @@ namespace jlcxx
 namespace stl
 {
 
-void apply_unordered_multiset_iterator(TypeWrapper1& unordered_multiset_iterator)
+void apply_unordered_multiset()
 {
-  unordered_multiset_iterator.apply_combination<stl::UnorderedMultisetIteratorWrapper, stltypes>(stl::WrapIterator());
-}
-
-void apply_unordered_multiset(TypeWrapper1& unordered_multiset)
-{
-  unordered_multiset.apply_combination<std::unordered_multiset, stltypes>(stl::WrapUnorderedMultiset());
+  WrapSTLContainer<std::unordered_multiset>().apply_combination<stltypes>();
 }
 
 }

--- a/src/stl_unordered_set.cpp
+++ b/src/stl_unordered_set.cpp
@@ -6,14 +6,9 @@ namespace jlcxx
 namespace stl
 {
 
-void apply_unordered_set_iterator(TypeWrapper1& unordered_set_iterator)
+void apply_unordered_set()
 {
-  unordered_set_iterator.apply_combination<stl::UnorderedSetIteratorWrapper, stltypes>(stl::WrapIterator());
-}
-
-void apply_unordered_set(TypeWrapper1& unordered_set)
-{
-  unordered_set.apply_combination<std::unordered_set, stltypes>(stl::WrapUnorderedSet());
+  WrapSTLContainer<std::unordered_set>().apply_combination<stltypes>();
 }
 
 }

--- a/src/stl_valarray.cpp
+++ b/src/stl_valarray.cpp
@@ -6,9 +6,9 @@ namespace jlcxx
 namespace stl
 {
 
-void apply_valarray(TypeWrapper1& valarray)
+void apply_valarray()
 {
-  valarray.apply_combination<std::valarray, stltypes>(stl::WrapValArray());
+  WrapSTLContainer<std::valarray>().apply_combination<stltypes>();
 }
 
 }

--- a/src/stl_vector.cpp
+++ b/src/stl_vector.cpp
@@ -6,9 +6,9 @@ namespace jlcxx
 namespace stl
 {
 
-void apply_vector(TypeWrapper1& vector)
+void apply_vector()
 {
-  vector.apply_combination<std::vector, stltypes>(stl::WrapVector());
+  WrapSTLContainer<std::vector>().apply_combination<stltypes>();
 }
 
 }


### PR DESCRIPTION
https://github.com/JuliaInterop/CxxWrap.jl#stl-updates

This should shorten macOS compile times again and fix problems with attempts
to put non-comparable types into e.g. `std::set`.