### PR TITLE
get_module_functions: separate gc pushes

### DIFF
--- a/include/jlcxx/jlcxx_config.hpp
+++ b/include/jlcxx/jlcxx_config.hpp
@@ -25,7 +25,7 @@
 
 // Apple Clang doesn't really support ranges fully until __cpp_lib_ranges==202207L (AppleClang 16)
 #if defined(__cpp_lib_ranges) && !defined(JLCXX_FORCE_RANGES_OFF)
-#  if defined(__clang__) && defined(__apple_build_version__)
+#  if (defined(__clang__) && defined(__apple_build_version__)) || defined _MSC_VER
 #    if __cpp_lib_ranges >= 202207L
 #      define JLCXX_HAS_RANGES
 #    endif

--- a/src/c_interface.cpp
+++ b/src/c_interface.cpp
@@ -147,7 +147,8 @@ JLCXX_API jl_array_t* get_module_functions(jl_module_t* jlmod)
        {
           Array<jl_value_t*> arg_default_values_array;
           jl_value_t* boxed_n_kwargs = nullptr;
-          JL_GC_PUSH2(arg_default_values_array.gc_pointer(), &boxed_n_kwargs);
+          jl_value_t* cppfuncinfo = nullptr;
+          JL_GC_PUSH3(arg_default_values_array.gc_pointer(), &boxed_n_kwargs, &cppfuncinfo);
 
           fill_types_vec(arg_types_array, f.argument_types());
 
@@ -169,7 +170,7 @@ JLCXX_API jl_array_t* get_module_functions(jl_module_t* jlmod)
             julia_return_type = ccall_return_type;
           }
 
-          function_array.push_back(jl_new_struct(g_cppfunctioninfo_type,
+          cppfuncinfo = jl_new_struct(g_cppfunctioninfo_type,
             f.name(),
             arg_types_array.wrapped(),
             ccall_return_type,
@@ -181,7 +182,8 @@ JLCXX_API jl_array_t* get_module_functions(jl_module_t* jlmod)
             arg_names_array.wrapped(),
             arg_default_values_array.wrapped(),
             boxed_n_kwargs
-          ));
+            );
+          function_array.push_back(cppfuncinfo);
           JL_GC_POP();
        }
        JL_GC_POP();

--- a/src/c_interface.cpp
+++ b/src/c_interface.cpp
@@ -140,45 +140,52 @@ JLCXX_API jl_array_t* get_module_functions(jl_module_t* jlmod)
     Array<jl_datatype_t*> arg_types_array;
     jl_value_t* boxed_f = nullptr;
     jl_value_t* boxed_thunk = nullptr;
-    Array<jl_value_t*> arg_names_array;
-    Array<jl_value_t*> arg_default_values_array;
-    jl_value_t* boxed_n_kwargs;
-    JL_GC_PUSH6(arg_types_array.gc_pointer(), &boxed_f, &boxed_thunk, arg_names_array.gc_pointer(), arg_default_values_array.gc_pointer(), &boxed_n_kwargs);
-
-    fill_types_vec(arg_types_array, f.argument_types());
-
-    boxed_f = jlcxx::box<void*>(f.pointer());
-    boxed_thunk = jlcxx::box<void*>(f.thunk());
-
-    fill_values_vec(arg_names_array, f.argument_names());
-    fill_values_vec(arg_default_values_array, f.argument_default_values());
-
-    boxed_n_kwargs = jlcxx::box<int>(f.number_of_keyword_arguments());
-
-    auto returntypes = f.return_type();
-
-    jl_datatype_t* ccall_return_type = returntypes.first;
-    jl_datatype_t* julia_return_type = returntypes.second;
-    if(ccall_return_type == nullptr)
+    JL_GC_PUSH3(arg_types_array.gc_pointer(), &boxed_f, &boxed_thunk);
     {
-      ccall_return_type = julia_type<void>();
-      julia_return_type = ccall_return_type;
+       Array<jl_value_t*> arg_names_array;
+       JL_GC_PUSH1(arg_names_array.gc_pointer());
+       {
+          Array<jl_value_t*> arg_default_values_array;
+          jl_value_t* boxed_n_kwargs = nullptr;
+          JL_GC_PUSH2(arg_default_values_array.gc_pointer(), &boxed_n_kwargs);
+
+          fill_types_vec(arg_types_array, f.argument_types());
+
+          boxed_f = jlcxx::box<void*>(f.pointer());
+          boxed_thunk = jlcxx::box<void*>(f.thunk());
+
+          fill_values_vec(arg_names_array, f.argument_names());
+          fill_values_vec(arg_default_values_array, f.argument_default_values());
+
+          boxed_n_kwargs = jlcxx::box<int>(f.number_of_keyword_arguments());
+
+          auto returntypes = f.return_type();
+
+          jl_datatype_t* ccall_return_type = returntypes.first;
+          jl_datatype_t* julia_return_type = returntypes.second;
+          if(ccall_return_type == nullptr)
+          {
+            ccall_return_type = julia_type<void>();
+            julia_return_type = ccall_return_type;
+          }
+
+          function_array.push_back(jl_new_struct(g_cppfunctioninfo_type,
+            f.name(),
+            arg_types_array.wrapped(),
+            ccall_return_type,
+            julia_return_type,
+            boxed_f,
+            boxed_thunk,
+            f.override_module(),
+            f.doc(),
+            arg_names_array.wrapped(),
+            arg_default_values_array.wrapped(),
+            boxed_n_kwargs
+          ));
+          JL_GC_POP();
+       }
+       JL_GC_POP();
     }
-
-    function_array.push_back(jl_new_struct(g_cppfunctioninfo_type,
-      f.name(),
-      arg_types_array.wrapped(),
-      ccall_return_type,
-      julia_return_type,
-      boxed_f,
-      boxed_thunk,
-      f.override_module(),
-      f.doc(),
-      arg_names_array.wrapped(),
-      arg_default_values_array.wrapped(),
-      boxed_n_kwargs
-    ));
-
     JL_GC_POP();
   });
   JL_GC_POP();

--- a/src/jlcxx.cpp
+++ b/src/jlcxx.cpp
@@ -457,4 +457,16 @@ JLCXX_API void cxxwrap_init(const std::string& envpath)
   }
 }
 
+#ifdef _MSC_VER 
+
+namespace detail
+{
+
+template class BasicArg<false>;
+template class BasicArg<true>;
+
+}
+
+#endif
+
 }


### PR DESCRIPTION
https://github.com/JuliaInterop/CxxWrap.jl#stl-updates

Creating a new `jlcxx::Array<...>()` calls `jl_alloc_array_1d` which can trigger garbage collection. Thus we need to protect each array before creating the next one, instead of doing one `JL_GC_PUSH6` call here:
https://github.com/JuliaInterop/libcxxwrap-julia/blob/d4192fe3ea20829bd399d812863abd8303f9bcab/src/c_interface.cpp#L138-L146

This might help with some rare crashes during initialization or precompilation we have seen in the Oscar CI for quite a while (see https://github.com/oscar-system/Oscar.jl/issues/3296).

The backtrace I got locally was:
```julia
Precompiling Oscar...                                              
  5 dependencies successfully precompiled in 242 seconds. 113 already precompiled.
                                                                   
[16014] signal 11 (1): Segmentation fault                          
in expression starting at none:1                                   
fill_types_vec at /tmp/rrprecomp/artifacts/dee31c8c121f2be2dd7c7b2ec3d41b2be90cc8c7/lib/libcxxwrap_julia.so (unknown line)
_ZZ20get_module_functionsENKUlRN5jlcxx19FunctionWrapperBaseEE_clES1_ at /tmp/rrprecomp/artifacts/dee31c8c121f2be2dd7c7b2ec3d41b2be90cc8c7/lib/libcxxwrap_julia.so (unknown line)                                                          
get_module_functions at /tmp/rrprecomp/artifacts/dee31c8c121f2be2dd7c7b2ec3d41b2be90cc8c7/lib/libcxxwrap_julia.so (unknown line)
get_module_functions at /tmp/rrprecomp/packages/CxxWrap/eWADG/src/CxxWrap.jl:444 [inlined]
initialize_julia_module at /tmp/rrprecomp/packages/CxxWrap/eWADG/src/CxxWrap.jl:433
__init__ at /tmp/rrprecomp/packages/CxxWrap/eWADG/src/StdLib.jl:25
jfptr___init___45622 at /tmp/rrprecomp/compiled/v1.11/CxxWrap/WGIJU_QbeCS.so (unknown line)
jl_apply at /cache/build/builder-demeter6-6/julialang/julia-master/src/julia.h:2157 [inlined]
jl_module_run_initializer at /cache/build/builder-demeter6-6/julialang/julia-master/src/toplevel.c:76
run_module_init at ./loading.jl:1336
register_restored_modules at ./loading.jl:1324
#_include_from_serialized#1066 at ./loading.jl:1213
_include_from_serialized at ./loading.jl:1169 [inlined]
_include_from_serialized at ./loading.jl:1169 [inlined]
#_require_search_from_serialized#1077 at ./loading.jl:1969
_require_search_from_serialized at ./loading.jl:1908
jfptr__require_search_from_serialized_44533.1 at /net/site-local.linux64/julia/julia-1.11.1/lib/julia/sys.so (unknown line)
_require at ./loading.jl:2450
__require_prelocked at ./loading.jl:2315
jfptr___require_prelocked_69877.1 at /net/site-local.linux64/julia/julia-1.11.1/lib/julia/sys.so (unknown line)
jl_apply at /cache/build/builder-demeter6-6/julialang/julia-master/src/julia.h:2157 [inlined]
jl_f__call_in_world at /cache/build/builder-demeter6-6/julialang/julia-master/src/builtins.c:894
#invoke_in_world#3 at ./essentials.jl:1089 [inlined]
invoke_in_world at ./essentials.jl:1086 [inlined]
_require_prelocked at ./loading.jl:2302
macro expansion at ./loading.jl:2241 [inlined]
macro expansion at ./lock.jl:273 [inlined]
__require at ./loading.jl:2198
jfptr___require_69814.1 at /net/site-local.linux64/julia/julia-1.11.1/lib/julia/sys.so (unknown line)
jl_apply at /cache/build/builder-demeter6-6/julialang/julia-master/src/julia.h:2157 [inlined]
jl_f__call_in_world at /cache/build/builder-demeter6-6/julialang/julia-master/src/builtins.c:894
#invoke_in_world#3 at ./essentials.jl:1089 [inlined]
invoke_in_world at ./essentials.jl:1086 [inlined]
require at ./loading.jl:2191
jfptr_require_69803.1 at /net/site-local.linux64/julia/julia-1.11.1/lib/julia/sys.so (unknown line)
jl_apply at /cache/build/builder-demeter6-6/julialang/julia-master/src/julia.h:2157 [inlined]
call_require at /cache/build/builder-demeter6-6/julialang/julia-master/src/toplevel.c:486 [inlined]
eval_import_path at /cache/build/builder-demeter6-6/julialang/julia-master/src/toplevel.c:523
jl_toplevel_eval_flex at /cache/build/builder-demeter6-6/julialang/julia-master/src/toplevel.c:759
jl_toplevel_eval_flex at /cache/build/builder-demeter6-6/julialang/julia-master/src/toplevel.c:886
ijl_toplevel_eval_in at /cache/build/builder-demeter6-6/julialang/julia-master/src/toplevel.c:994
eval at ./boot.jl:430 [inlined]
```
~~Unfortunately this is slightly different from the backtraces in the Oscar CI but it might still be related and I could not reproduce the other backtrace yet.~~

~~I will keep it a draft for now as I dig into another backtrace I just got,~~ but happy to receive some feedback. Maybe there is another good way to protect these Arrays?

cc: @fingolfin 

Note: the diff is best viewed with ignore whitespace enabled: https://github.com/JuliaInterop/libcxxwrap-julia/pull/177/files?w=1

_Edit:_ running against `stl-updates` branch because otherwise the version doesn't fit to the main branch here. I did my debugging with libcxxwrap-julia 0.13.2 though.

_Edit2:_
The second crash (which is closer to the backtrace from the Oscar CI) appeared after fixing the first one and should be fixed with the second commit by protecting the CppFunctionInfo struct during the `push_back` (which grows the array and thus allocates).
Another option to fix this would be to add a special version of `push_back` for `jl_value_t*` which also adds the argument to the `JL_GC_PUSH` macro. This would help for other users of `Array<jl_value_t*>` where the argument might be unprotected.

<details>
<summary>backtrace for the second crash:</summary>

```
[17115] signal 11 (1): Segmentation fault                           
in expression starting at /tmp/rrprecomp/packages/Hecke/Pu8AF/ext/PolymakeExt.jl:3
jl_is_layout_opaque at /cache/build/builder-demeter6-6/julialang/julia-master/src/julia.h:1330 [inlined]
jl_datatype_layout at /cache/build/builder-demeter6-6/julialang/julia-master/src/julia.h:1338 [inlined]
jl_f_tuple at /cache/build/builder-demeter6-6/julialang/julia-master/src/builtins.c:936 [inlined]
jl_f_tuple at /cache/build/builder-demeter6-6/julialang/julia-master/src/builtins.c:926
jl_method_error at /cache/build/builder-demeter6-6/julialang/julia-master/src/gf.c:2270
jl_lookup_generic_ at /cache/build/builder-demeter6-6/julialang/julia-master/src/gf.c:3106 [inlined]
ijl_apply_generic at /cache/build/builder-demeter6-6/julialang/julia-master/src/gf.c:3121
#408 at ./compiler/typeutils.jl:57
anymap at ./compiler/utilities.jl:43 [inlined]
argtypes_to_type at ./compiler/typeutils.jl:57
abstract_call_known at ./compiler/abstractinterpretation.jl:2199
abstract_call at ./compiler/abstractinterpretation.jl:2282
abstract_call at ./compiler/abstractinterpretation.jl:2275
abstract_call at ./compiler/abstractinterpretation.jl:2420
abstract_eval_call at ./compiler/abstractinterpretation.jl:2435
abstract_eval_statement_expr at ./compiler/abstractinterpretation.jl:2451
abstract_eval_statement at ./compiler/abstractinterpretation.jl:2749
abstract_eval_basic_statement at ./compiler/abstractinterpretation.jl:3041
typeinf_local at ./compiler/abstractinterpretation.jl:3319
typeinf_nocycle at ./compiler/abstractinterpretation.jl:3401
_typeinf at ./compiler/typeinfer.jl:244
typeinf at ./compiler/typeinfer.jl:215
typeinf_ext at ./compiler/typeinfer.jl:1101
typeinf_ext_toplevel at ./compiler/typeinfer.jl:1139
typeinf_ext_toplevel at ./compiler/typeinfer.jl:1135
jfptr_typeinf_ext_toplevel_39647.1 at /net/site-local.linux64/julia/julia-1.11.1/lib/julia/sys.so (unknown line)
jl_apply at /cache/build/builder-demeter6-6/julialang/julia-master/src/julia.h:2157 [inlined]
jl_type_infer at /cache/build/builder-demeter6-6/julialang/julia-master/src/gf.c:390
jl_generate_fptr_impl at /cache/build/builder-demeter6-6/julialang/julia-master/src/jitlayers.cpp:511
jl_compile_method_internal at /cache/build/builder-demeter6-6/julialang/julia-master/src/gf.c:2536 [inlined]
jl_compile_method_internal at /cache/build/builder-demeter6-6/julialang/julia-master/src/gf.c:2423
_jl_invoke at /cache/build/builder-demeter6-6/julialang/julia-master/src/gf.c:2940 [inlined]
ijl_apply_generic at /cache/build/builder-demeter6-6/julialang/julia-master/src/gf.c:3125
initialize_julia_module at /tmp/rrprecomp/packages/CxxWrap/eWADG/src/CxxWrap.jl:436
__init__ at /tmp/rrprecomp/packages/Polymake/nU3NN/src/Polymake.jl:108
unknown function (ip: 0x14b3a38073bf)
jl_apply at /cache/build/builder-demeter6-6/julialang/julia-master/src/julia.h:2157 [inlined]
jl_module_run_initializer at /cache/build/builder-demeter6-6/julialang/julia-master/src/toplevel.c:76
run_module_init at ./loading.jl:1336
```

</details>