### PR TITLE
Refactor inheritance wrapping mechanics to catch missing `SuperType` specialization at compile time

### DIFF
--- a/examples/inheritance.cpp
+++ b/examples/inheritance.cpp
@@ -223,9 +223,9 @@ namespace jlcxx
 JLCXX_MODULE define_types_module(jlcxx::Module& types)
 {
   types.add_type<A>("A").method("message", &A::message);
-  types.add_type<B>("B", jlcxx::julia_base_type<A>());
-  types.add_type<C>("C", jlcxx::julia_base_type<B>());
-  types.add_type<D>("D", jlcxx::julia_base_type<A>());
+  types.add_type<B>("B", jlcxx::cxx_supertype<A>());
+  types.add_type<C>("C", jlcxx::cxx_supertype<B>());
+  types.add_type<D>("D", jlcxx::cxx_supertype<A>());
   types.method("create_abstract", create_abstract);
 
   types.method("shared_b", []() { return std::make_shared<B>(); });
@@ -241,14 +241,14 @@ JLCXX_MODULE define_types_module(jlcxx::Module& types)
   types.method("take_ref", take_ref);
 
   types.add_type<StaticBase>("StaticBase");
-  types.add_type<StaticDerived>("StaticDerived", jlcxx::julia_base_type<StaticBase>());
+  types.add_type<StaticDerived>("StaticDerived", jlcxx::cxx_supertype<StaticBase>());
 
   types.add_type<VirtualCpp>("VirtualCpp")
     .method("virtualfunc", &VirtualCpp::virtualfunc);
-  types.add_type<VirtualCppJuliaExtended>("VirtualCppJuliaExtended", jlcxx::julia_base_type<VirtualCpp>())
+  types.add_type<VirtualCppJuliaExtended>("VirtualCppJuliaExtended", jlcxx::cxx_supertype<VirtualCpp>())
     .constructor<int, double>()
     .method("set_callback", &VirtualCppJuliaExtended::set_callback);
-  types.add_type<VirtualCfunctionExtended>("VirtualCfunctionExtended", jlcxx::julia_base_type<VirtualCpp>())
+  types.add_type<VirtualCfunctionExtended>("VirtualCfunctionExtended", jlcxx::cxx_supertype<VirtualCpp>())
     .constructor<int, double>()
     .method("getData", &VirtualCfunctionExtended::getData)
     .method("set_callback", &VirtualCfunctionExtended::set_callback);
@@ -256,10 +256,10 @@ JLCXX_MODULE define_types_module(jlcxx::Module& types)
   types.add_type<Parent>("Parent")
         .method("name", &Parent::name);
 
-  types.add_type<DerivedA>("DerivedA", jlcxx::julia_base_type<Parent>())
+  types.add_type<DerivedA>("DerivedA", jlcxx::cxx_supertype<Parent>())
       .method("name", &DerivedA::name);
 
-  types.add_type<DerivedB>("DerivedB", jlcxx::julia_base_type<Parent>())
+  types.add_type<DerivedB>("DerivedB", jlcxx::cxx_supertype<Parent>())
       .method("name", &DerivedB::name);
 
   types.method("make_a", &make_a);
@@ -273,7 +273,7 @@ JLCXX_MODULE define_vsolver_module(jlcxx::Module& vsolver_mod)
   vsolver_mod.add_type<virtualsolver::Base>("BaseV")
     .method("solve", &virtualsolver::Base::solve);
 
-  vsolver_mod.add_type<virtualsolver::E>("E", jlcxx::julia_base_type<virtualsolver::Base>());
-  vsolver_mod.add_type<virtualsolver::F>("F", jlcxx::julia_base_type<virtualsolver::Base>())
+  vsolver_mod.add_type<virtualsolver::E>("E", jlcxx::cxx_supertype<virtualsolver::Base>());
+  vsolver_mod.add_type<virtualsolver::F>("F", jlcxx::cxx_supertype<virtualsolver::Base>())
     .constructor<virtualsolver::history_f>();
 }

--- a/examples/inheritance.cpp
+++ b/examples/inheritance.cpp
@@ -223,9 +223,9 @@ namespace jlcxx
 JLCXX_MODULE define_types_module(jlcxx::Module& types)
 {
   types.add_type<A>("A").method("message", &A::message);
-  types.add_type<B>("B", jlcxx::cxx_supertype<A>());
-  types.add_type<C>("C", jlcxx::cxx_supertype<B>());
-  types.add_type<D>("D", jlcxx::cxx_supertype<A>());
+  types.add_type<B>("B", jlcxx::julia_base_type<A>());
+  types.add_type<C>("C", jlcxx::julia_base_type<B>());
+  types.add_type<D>("D", jlcxx::julia_base_type<A>());
   types.method("create_abstract", create_abstract);
 
   types.method("shared_b", []() { return std::make_shared<B>(); });
@@ -241,14 +241,14 @@ JLCXX_MODULE define_types_module(jlcxx::Module& types)
   types.method("take_ref", take_ref);
 
   types.add_type<StaticBase>("StaticBase");
-  types.add_type<StaticDerived>("StaticDerived", jlcxx::cxx_supertype<StaticBase>());
+  types.add_type<StaticDerived>("StaticDerived", jlcxx::julia_base_type<StaticBase>());
 
   types.add_type<VirtualCpp>("VirtualCpp")
     .method("virtualfunc", &VirtualCpp::virtualfunc);
-  types.add_type<VirtualCppJuliaExtended>("VirtualCppJuliaExtended", jlcxx::cxx_supertype<VirtualCpp>())
+  types.add_type<VirtualCppJuliaExtended>("VirtualCppJuliaExtended", jlcxx::julia_base_type<VirtualCpp>())
     .constructor<int, double>()
     .method("set_callback", &VirtualCppJuliaExtended::set_callback);
-  types.add_type<VirtualCfunctionExtended>("VirtualCfunctionExtended", jlcxx::cxx_supertype<VirtualCpp>())
+  types.add_type<VirtualCfunctionExtended>("VirtualCfunctionExtended", jlcxx::julia_base_type<VirtualCpp>())
     .constructor<int, double>()
     .method("getData", &VirtualCfunctionExtended::getData)
     .method("set_callback", &VirtualCfunctionExtended::set_callback);
@@ -256,10 +256,10 @@ JLCXX_MODULE define_types_module(jlcxx::Module& types)
   types.add_type<Parent>("Parent")
         .method("name", &Parent::name);
 
-  types.add_type<DerivedA>("DerivedA", jlcxx::cxx_supertype<Parent>())
+  types.add_type<DerivedA>("DerivedA", jlcxx::julia_base_type<Parent>())
       .method("name", &DerivedA::name);
 
-  types.add_type<DerivedB>("DerivedB", jlcxx::cxx_supertype<Parent>())
+  types.add_type<DerivedB>("DerivedB", jlcxx::julia_base_type<Parent>())
       .method("name", &DerivedB::name);
 
   types.method("make_a", &make_a);
@@ -273,7 +273,7 @@ JLCXX_MODULE define_vsolver_module(jlcxx::Module& vsolver_mod)
   vsolver_mod.add_type<virtualsolver::Base>("BaseV")
     .method("solve", &virtualsolver::Base::solve);
 
-  vsolver_mod.add_type<virtualsolver::E>("E", jlcxx::cxx_supertype<virtualsolver::Base>());
-  vsolver_mod.add_type<virtualsolver::F>("F", jlcxx::cxx_supertype<virtualsolver::Base>())
+  vsolver_mod.add_type<virtualsolver::E>("E", jlcxx::julia_base_type<virtualsolver::Base>());
+  vsolver_mod.add_type<virtualsolver::F>("F", jlcxx::julia_base_type<virtualsolver::Base>())
     .constructor<virtualsolver::history_f>();
 }

--- a/examples/parametric.cpp
+++ b/examples/parametric.cpp
@@ -294,7 +294,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& types)
   auto template_type = types.add_type<Parametric<TypeVar<1>, TypeVar<2>>>("TemplateType");
   template_type.apply<TemplateType<P1,P2>, TemplateType<P2,P1>>(WrapTemplateType());
 
-  types.add_type<Parametric<TypeVar<2>>, ParameterList<P2, TypeVar<2>>>("PartialTemplate", jlcxx::cxx_supertype(template_type))
+  types.add_type<Parametric<TypeVar<2>>, ParameterList<P2, TypeVar<2>>>("PartialTemplate", jlcxx::julia_base_type(template_type))
     .apply<PartialTemplate<P1>>(WrapPartialTemplateType());
 
   types.add_type<Parametric<TypeVar<1>>>("TemplateDefaultType")
@@ -306,7 +306,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& types)
   auto abstract_template = types.add_type<Parametric<jlcxx::TypeVar<1>>>("AbstractTemplate");
   abstract_template.apply<AbstractTemplate<double>>(WrapAbstractTemplate());
 
-  types.add_type<Parametric<jlcxx::TypeVar<1>>>("ConcreteTemplate", jlcxx::cxx_supertype(abstract_template)).apply<ConcreteTemplate<double>>(WrapConcreteTemplate());
+  types.add_type<Parametric<jlcxx::TypeVar<1>>>("ConcreteTemplate", jlcxx::julia_base_type(abstract_template)).apply<ConcreteTemplate<double>>(WrapConcreteTemplate());
 
   typedef jlcxx::combine_types<jlcxx::ApplyType<Foo3>, ParameterList<int32_t, double>, ParameterList<P1,P2,bool>, ParameterList<float>> foo3_types;
   static_assert(std::is_same_v<foo3_types,

--- a/examples/parametric.cpp
+++ b/examples/parametric.cpp
@@ -276,6 +276,8 @@ namespace jlcxx
   template<typename T> struct IsMirroredType<PartialTemplate<T>> : std::false_type { };
   template<typename T> struct SuperType<PartialTemplate<T>> { typedef TemplateType<P2,T> type; };
 
+  template<typename T> struct SuperType<ConcreteTemplate<T>> { typedef AbstractTemplate<T> type; };
+
   template<typename T> struct IsMirroredType<CyclicParamDepA<T>> : std::false_type { };
   template<typename T> struct IsMirroredType<CyclicParamDepB<T>> : std::false_type { };
 
@@ -292,7 +294,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& types)
   auto template_type = types.add_type<Parametric<TypeVar<1>, TypeVar<2>>>("TemplateType");
   template_type.apply<TemplateType<P1,P2>, TemplateType<P2,P1>>(WrapTemplateType());
 
-  types.add_type<Parametric<TypeVar<2>>, ParameterList<P2, TypeVar<2>>>("PartialTemplate", template_type.dt())
+  types.add_type<Parametric<TypeVar<2>>, ParameterList<P2, TypeVar<2>>>("PartialTemplate", jlcxx::cxx_supertype(template_type))
     .apply<PartialTemplate<P1>>(WrapPartialTemplateType());
 
   types.add_type<Parametric<TypeVar<1>>>("TemplateDefaultType")
@@ -304,7 +306,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& types)
   auto abstract_template = types.add_type<Parametric<jlcxx::TypeVar<1>>>("AbstractTemplate");
   abstract_template.apply<AbstractTemplate<double>>(WrapAbstractTemplate());
 
-  types.add_type<Parametric<jlcxx::TypeVar<1>>>("ConcreteTemplate", abstract_template.dt()).apply<ConcreteTemplate<double>>(WrapConcreteTemplate());
+  types.add_type<Parametric<jlcxx::TypeVar<1>>>("ConcreteTemplate", jlcxx::cxx_supertype(abstract_template)).apply<ConcreteTemplate<double>>(WrapConcreteTemplate());
 
   typedef jlcxx::combine_types<jlcxx::ApplyType<Foo3>, ParameterList<int32_t, double>, ParameterList<P1,P2,bool>, ParameterList<float>> foo3_types;
   static_assert(std::is_same_v<foo3_types,

--- a/include/jlcxx/jlcxx_config.hpp
+++ b/include/jlcxx/jlcxx_config.hpp
@@ -16,7 +16,7 @@
 
 #define JLCXX_VERSION_MAJOR 0
 #define JLCXX_VERSION_MINOR 14
-#define JLCXX_VERSION_PATCH 9
+#define JLCXX_VERSION_PATCH 10
 
 // From https://stackoverflow.com/questions/5459868/concatenate-int-to-string-using-c-preprocessor
 #define __JLCXX_STR_HELPER(x) #x

--- a/include/jlcxx/module.hpp
+++ b/include/jlcxx/module.hpp
@@ -301,7 +301,7 @@ struct Parametric
 
 template<typename... T> struct IsMirroredType<Parametric<T...>> : std::false_type {};
 
-template<typename T>
+template<typename T, bool CxxInheritor = false>
 class TypeWrapper;
 
 namespace detail
@@ -529,6 +529,14 @@ struct CopyConstructible : std::bool_constant<std::is_copy_constructible_v<T> &&
 {
 };
 
+/// Tag type for signalling C++ inheritance to add_type, enabling compile-time SuperType enforcement
+template<typename BaseT>
+struct CxxBaseTag { jl_datatype_t* dt; };
+
+/// Use as the super argument to add_type to declare C++ inheritance from a non-parametric base
+template<typename BaseT>
+CxxBaseTag<BaseT> cxx_supertype() { return {julia_base_type<BaseT>()}; }
+
 /// Store all exposed C++ functions associated with a module
 class JLCXX_API Module
 {
@@ -651,6 +659,10 @@ public:
   template<typename T, typename SuperParametersT=ParameterList<>, typename JLSuperT=jl_datatype_t>
   TypeWrapper<T> add_type(const std::string& name, JLSuperT* super = jl_any_type);
 
+  /// Add a composite type with C++ inheritance — enforces SuperType<T> at compile time
+  template<typename T, typename SuperParametersT=ParameterList<>, typename BaseT>
+  auto add_type(const std::string& name, CxxBaseTag<BaseT> super);
+
   /// Add types that are directly mapped to a Julia struct
   template<typename T>
   void map_type(const std::string& name)
@@ -770,8 +782,8 @@ private:
     }
   }
 
-  template<typename T, typename SuperParametersT, typename JLSuperT>
-  TypeWrapper<T> add_type_internal(const std::string& name, JLSuperT* super);
+  template<typename T, typename SuperParametersT, bool CxxInheritor = false, typename JLSuperT>
+  TypeWrapper<T, CxxInheritor> add_type_internal(const std::string& name, JLSuperT* super);
 
   template<typename LambdaT>
   FunctionWrapperBase& add_lambda(const std::string& name, LambdaT&& lambda, detail::ExtraFunctionData&& extraData)
@@ -807,8 +819,8 @@ private:
   Array<jl_value_t*> m_constant_values;
   std::vector<jl_datatype_t*> m_box_types;
 
-  template<class T> friend class TypeWrapper;
-  template<typename T, typename... AppliedTypesT> friend class ParametricTypeWrappers;
+  template<class T, bool CxxInheritor> friend class TypeWrapper;
+  template<typename T, bool CxxInheritor, typename... AppliedTypesT> friend class ParametricTypeWrappers;
 };
 
 template<typename T>
@@ -1113,11 +1125,11 @@ inline void add_default_methods(Module& mod)
   mod.unset_override_module();
 }
 
-template<typename T, typename... AppliedTypesT>
+template<typename T, bool CxxInheritor, typename... AppliedTypesT>
 class ParametricTypeWrappers;
 
 /// Helper class to wrap type methods
-template<typename T>
+template<typename T, bool CxxInheritor>
 class TypeWrapper
 {
 public:
@@ -1214,14 +1226,14 @@ public:
   }
 
   template<typename... AppliedTypesT>
-  ParametricTypeWrappers<T, AppliedTypesT...> apply()
+  ParametricTypeWrappers<T, CxxInheritor, AppliedTypesT...> apply()
   {
     static_assert(detail::IsParametric<T>::value, "Apply can only be called on parametric types");
-    return ParametricTypeWrappers<T, AppliedTypesT...>(*this);
+    return ParametricTypeWrappers<T, CxxInheritor, AppliedTypesT...>(*this);
   }
 
   template<typename... AppliedTypesT, typename FunctorT>
-  TypeWrapper<T>& apply(FunctorT&& apply_ftor)
+  TypeWrapper<T, CxxInheritor>& apply(FunctorT&& apply_ftor)
   {
     static_assert(detail::IsParametric<T>::value, "Apply can only be called on parametric types");
     apply<AppliedTypesT...>().apply(std::forward<FunctorT>(apply_ftor));
@@ -1241,7 +1253,7 @@ public:
     return m_module;
   }
 
-  jl_datatype_t* dt()
+  jl_datatype_t* dt() const
   {
     return m_dt;
   }
@@ -1252,10 +1264,14 @@ private:
   jl_datatype_t* m_dt;
   jl_datatype_t* m_box_dt;
 
-  template<typename U, typename... AppliedTypesT> friend class ParametricTypeWrappers;
+  template<typename U, bool, typename... AppliedTypesT> friend class ParametricTypeWrappers;
 };
 
 using TypeWrapper1 = TypeWrapper<Parametric<TypeVar<1>>>;
+
+/// Use as the super argument to add_type to declare C++ inheritance from a parametric base
+template<typename BaseT, bool CxxInheritor>
+CxxBaseTag<BaseT> cxx_supertype(const TypeWrapper<BaseT, CxxInheritor>& t) { return {t.dt()}; }
 
 #ifdef JLCXX_USE_TYPE_MAP
 JLCXX_API std::shared_ptr<TypeWrapper1>& jlcxx_smartpointer_type(std::type_index idx);
@@ -1263,22 +1279,22 @@ JLCXX_API std::shared_ptr<TypeWrapper1>& jlcxx_smartpointer_type(std::type_index
 
 template<typename ApplyT, typename... TypeLists> using combine_types = typename CombineTypes<ApplyT, TypeLists...>::type;
 
-template<typename T>
+template<typename T, bool CxxInheritor>
 template<template<typename...> class TemplateT, typename... TypeLists, typename FunctorT>
-void TypeWrapper<T>::apply_combination(FunctorT&& ftor)
+void TypeWrapper<T, CxxInheritor>::apply_combination(FunctorT&& ftor)
 {
   this->template apply_combination<ApplyType<TemplateT>, TypeLists...>(std::forward<FunctorT>(ftor));
 }
 
-template<typename T>
+template<typename T, bool CxxInheritor>
 template<typename ApplyT, typename... TypeLists, typename FunctorT>
-void TypeWrapper<T>::apply_combination(FunctorT&& ftor)
+void TypeWrapper<T, CxxInheritor>::apply_combination(FunctorT&& ftor)
 {
   detail::DoApply<combine_types<ApplyT, TypeLists...>>()(*this, std::forward<FunctorT>(ftor));
 }
 
-template<typename T, typename SuperParametersT, typename JLSuperT>
-TypeWrapper<T> Module::add_type_internal(const std::string& name, JLSuperT* super_generic)
+template<typename T, typename SuperParametersT, bool CxxInheritor, typename JLSuperT>
+TypeWrapper<T, CxxInheritor> Module::add_type_internal(const std::string& name, JLSuperT* super_generic)
 {
   static constexpr bool is_parametric = detail::IsParametric<T>::value;
   static_assert(!IsMirroredType<T>::value, "Mirrored types (marked with IsMirroredType) can't be added using add_type, map them directly to a struct instead and use map_type or explicitly disable mirroring for this type, e.g. define template<> struct IsMirroredType<Foo> : std::false_type { };");
@@ -1352,7 +1368,7 @@ TypeWrapper<T> Module::add_type_internal(const std::string& name, JLSuperT* supe
   }
 
   JL_GC_POP();
-  return TypeWrapper<T>(*this, base_dt, box_dt);
+  return TypeWrapper<T, CxxInheritor>(*this, base_dt, box_dt);
 }
 
 /// Add a composite type
@@ -1360,6 +1376,23 @@ template<typename T, typename SuperParametersT, typename JLSuperT>
 TypeWrapper<T> Module::add_type(const std::string& name, JLSuperT* super)
 {
   return add_type_internal<T, SuperParametersT>(name, super);
+}
+
+/// Add a composite type with C++ inheritance — enforces SuperType<T> at compile time
+template<typename T, typename SuperParametersT, typename BaseT>
+auto Module::add_type(const std::string& name, CxxBaseTag<BaseT> super)
+{
+  if constexpr (!detail::IsParametric<T>::value)
+  {
+    static_assert(!std::is_same_v<supertype<T>, T>,
+      "SuperType<T> must be specialized when using cxx_supertype(). "
+      "Add: template<> struct jlcxx::SuperType<T> { typedef Base type; };");
+    return add_type_internal<T, SuperParametersT>(name, super.dt);
+  }
+  else
+  {
+    return add_type_internal<T, SuperParametersT, true>(name, super.dt);
+  }
 }
 
 /// Collection of the wrappers of each class template instantiation, that is on
@@ -1370,11 +1403,11 @@ TypeWrapper<T> Module::add_type(const std::string& name, JLSuperT* super)
 /// The method ParametricTypeWrappers::apply(FunctorT&&) can then be used to add
 /// the wrappers for the class template methods.
 ///
-template<typename T, typename... AppliedTypesT>
+template<typename T, bool CxxInheritor, typename... AppliedTypesT>
 class ParametricTypeWrappers
 {
 public:
-  ParametricTypeWrappers(TypeWrapper<T>& base_wrapper):
+  ParametricTypeWrappers(TypeWrapper<T, CxxInheritor>& base_wrapper):
     m_generic_type(base_wrapper),
     m_specialized_types(std::make_tuple(create_type<AppliedTypesT>()...))
   {
@@ -1417,6 +1450,9 @@ private:
   TypeWrapper<AppliedT>
   create_type()
   {
+    static_assert(!CxxInheritor || !std::is_same_v<supertype<AppliedT>, AppliedT>,
+      "SuperType<T> must be specialized when using cxx_supertype(). "
+      "Add: template<> struct jlcxx::SuperType<T> { typedef Base type; };");
     static_assert(!IsMirroredType<AppliedT>::value, "Mirrored type templates can't be added using add_type and apply, you should explicitly disable mirroring for this type, e.g. define template<typename... T> struct IsMirroredType<Foo<T...>> : std::false_type { }; in the jlcxx namespace.");
 
     static constexpr int nb_julia_parameters = parameter_list<T>::nb_parameters;
@@ -1449,7 +1485,7 @@ private:
   }
 
 private:
-  TypeWrapper<T>& m_generic_type;
+  TypeWrapper<T, CxxInheritor>& m_generic_type;
   std::tuple<TypeWrapper<AppliedTypesT>...> m_specialized_types;
 };
 

--- a/include/jlcxx/module.hpp
+++ b/include/jlcxx/module.hpp
@@ -301,7 +301,26 @@ struct Parametric
 
 template<typename... T> struct IsMirroredType<Parametric<T...>> : std::false_type {};
 
-template<typename T, bool CxxInheritor = false>
+/// Indicate that the parametric type has a type hierarchy and the existence of
+/// a SuperType specialisation must be enforced at compile time
+template<typename BaseT, typename ParametricT>
+struct InheritedParametric
+{
+  using base_type = BaseT;
+  using parametric_type = ParametricT;
+};
+
+template<typename BaseT, typename ParametricT> struct IsMirroredType<InheritedParametric<BaseT, ParametricT>> : std::false_type {};
+
+namespace detail
+{
+
+template<typename T> struct IsInheritedParametric : std::false_type {};
+template<typename BaseT, typename ParametricT> struct IsInheritedParametric<InheritedParametric<BaseT, ParametricT>> : std::true_type {};
+
+}
+
+template<typename T>
 class TypeWrapper;
 
 namespace detail
@@ -360,6 +379,12 @@ struct IsParametric
 
 template<template<typename...> class T, int I, typename... ParametersT>
 struct IsParametric<T<TypeVar<I>, ParametersT...>>
+{
+  static constexpr bool value = true;
+};
+
+template<typename BaseT, typename ParametersT>
+struct IsParametric<InheritedParametric<BaseT, ParametersT>>
 {
   static constexpr bool value = true;
 };
@@ -528,14 +553,6 @@ template <typename T>
 struct CopyConstructible : std::bool_constant<std::is_copy_constructible_v<T> && !std::is_abstract_v<T>>
 {
 };
-
-/// Tag type for signalling C++ inheritance to add_type, enabling compile-time SuperType enforcement
-template<typename BaseT>
-struct CxxBaseTag { jl_datatype_t* dt; };
-
-/// Use as the super argument to add_type to declare C++ inheritance from a non-parametric base
-template<typename BaseT>
-CxxBaseTag<BaseT> cxx_supertype() { return {julia_base_type<BaseT>()}; }
 
 /// Store all exposed C++ functions associated with a module
 class JLCXX_API Module
@@ -782,8 +799,8 @@ private:
     }
   }
 
-  template<typename T, typename SuperParametersT, bool CxxInheritor = false, typename JLSuperT>
-  TypeWrapper<T, CxxInheritor> add_type_internal(const std::string& name, JLSuperT* super);
+  template<typename T, typename SuperParametersT, typename JLSuperT>
+  TypeWrapper<T> add_type_internal(const std::string& name, JLSuperT* super);
 
   template<typename LambdaT>
   FunctionWrapperBase& add_lambda(const std::string& name, LambdaT&& lambda, detail::ExtraFunctionData&& extraData)
@@ -819,8 +836,8 @@ private:
   Array<jl_value_t*> m_constant_values;
   std::vector<jl_datatype_t*> m_box_types;
 
-  template<class T, bool CxxInheritor> friend class TypeWrapper;
-  template<typename T, bool CxxInheritor, typename... AppliedTypesT> friend class ParametricTypeWrappers;
+  template<class T> friend class TypeWrapper;
+  template<typename T, typename... AppliedTypesT> friend class ParametricTypeWrappers;
 };
 
 template<typename T>
@@ -841,6 +858,13 @@ struct BuildParameterList
 };
 
 template<typename T> using parameter_list = typename BuildParameterList<T>::type;
+
+// Take into account inheritance with compile-time check of SuperType definition
+template<typename BaseT, typename ParametersT>
+struct BuildParameterList<InheritedParametric<BaseT, ParametersT>>
+{
+  using type = typename BuildParameterList<ParametersT>::type;
+};
 
 // Match any combination of types only
 template<template<typename...> class T, typename... ParametersT>
@@ -1125,11 +1149,11 @@ inline void add_default_methods(Module& mod)
   mod.unset_override_module();
 }
 
-template<typename T, bool CxxInheritor, typename... AppliedTypesT>
+template<typename T, typename... AppliedTypesT>
 class ParametricTypeWrappers;
 
 /// Helper class to wrap type methods
-template<typename T, bool CxxInheritor>
+template<typename T>
 class TypeWrapper
 {
 public:
@@ -1226,14 +1250,14 @@ public:
   }
 
   template<typename... AppliedTypesT>
-  ParametricTypeWrappers<T, CxxInheritor, AppliedTypesT...> apply()
+  ParametricTypeWrappers<T, AppliedTypesT...> apply()
   {
     static_assert(detail::IsParametric<T>::value, "Apply can only be called on parametric types");
-    return ParametricTypeWrappers<T, CxxInheritor, AppliedTypesT...>(*this);
+    return ParametricTypeWrappers<T, AppliedTypesT...>(*this);
   }
 
   template<typename... AppliedTypesT, typename FunctorT>
-  TypeWrapper<T, CxxInheritor>& apply(FunctorT&& apply_ftor)
+  TypeWrapper<T>& apply(FunctorT&& apply_ftor)
   {
     static_assert(detail::IsParametric<T>::value, "Apply can only be called on parametric types");
     apply<AppliedTypesT...>().apply(std::forward<FunctorT>(apply_ftor));
@@ -1264,14 +1288,14 @@ private:
   jl_datatype_t* m_dt;
   jl_datatype_t* m_box_dt;
 
-  template<typename U, bool, typename... AppliedTypesT> friend class ParametricTypeWrappers;
+  template<typename U, typename... AppliedTypesT> friend class ParametricTypeWrappers;
 };
 
 using TypeWrapper1 = TypeWrapper<Parametric<TypeVar<1>>>;
 
 /// Use as the super argument to add_type to declare C++ inheritance from a parametric base
-template<typename BaseT, bool CxxInheritor>
-CxxBaseTag<BaseT> cxx_supertype(const TypeWrapper<BaseT, CxxInheritor>& t) { return {t.dt()}; }
+template<typename BaseT>
+CxxBaseTag<BaseT> julia_base_type(const TypeWrapper<BaseT>& t) { return {t.dt()}; }
 
 #ifdef JLCXX_USE_TYPE_MAP
 JLCXX_API std::shared_ptr<TypeWrapper1>& jlcxx_smartpointer_type(std::type_index idx);
@@ -1279,22 +1303,22 @@ JLCXX_API std::shared_ptr<TypeWrapper1>& jlcxx_smartpointer_type(std::type_index
 
 template<typename ApplyT, typename... TypeLists> using combine_types = typename CombineTypes<ApplyT, TypeLists...>::type;
 
-template<typename T, bool CxxInheritor>
+template<typename T>
 template<template<typename...> class TemplateT, typename... TypeLists, typename FunctorT>
-void TypeWrapper<T, CxxInheritor>::apply_combination(FunctorT&& ftor)
+void TypeWrapper<T>::apply_combination(FunctorT&& ftor)
 {
   this->template apply_combination<ApplyType<TemplateT>, TypeLists...>(std::forward<FunctorT>(ftor));
 }
 
-template<typename T, bool CxxInheritor>
+template<typename T>
 template<typename ApplyT, typename... TypeLists, typename FunctorT>
-void TypeWrapper<T, CxxInheritor>::apply_combination(FunctorT&& ftor)
+void TypeWrapper<T>::apply_combination(FunctorT&& ftor)
 {
   detail::DoApply<combine_types<ApplyT, TypeLists...>>()(*this, std::forward<FunctorT>(ftor));
 }
 
-template<typename T, typename SuperParametersT, bool CxxInheritor, typename JLSuperT>
-TypeWrapper<T, CxxInheritor> Module::add_type_internal(const std::string& name, JLSuperT* super_generic)
+template<typename T, typename SuperParametersT, typename JLSuperT>
+TypeWrapper<T> Module::add_type_internal(const std::string& name, JLSuperT* super_generic)
 {
   static constexpr bool is_parametric = detail::IsParametric<T>::value;
   static_assert(!IsMirroredType<T>::value, "Mirrored types (marked with IsMirroredType) can't be added using add_type, map them directly to a struct instead and use map_type or explicitly disable mirroring for this type, e.g. define template<> struct IsMirroredType<Foo> : std::false_type { };");
@@ -1368,7 +1392,7 @@ TypeWrapper<T, CxxInheritor> Module::add_type_internal(const std::string& name, 
   }
 
   JL_GC_POP();
-  return TypeWrapper<T, CxxInheritor>(*this, base_dt, box_dt);
+  return TypeWrapper<T>(*this, base_dt, box_dt);
 }
 
 /// Add a composite type
@@ -1385,13 +1409,13 @@ auto Module::add_type(const std::string& name, CxxBaseTag<BaseT> super)
   if constexpr (!detail::IsParametric<T>::value)
   {
     static_assert(!std::is_same_v<supertype<T>, T>,
-      "SuperType<T> must be specialized when using cxx_supertype(). "
+      "SuperType<T> must be specialized when using julia_base_type(). "
       "Add: template<> struct jlcxx::SuperType<T> { typedef Base type; };");
-    return add_type_internal<T, SuperParametersT>(name, super.dt);
+      return add_type_internal<T, SuperParametersT>(name, super.dt);
   }
   else
   {
-    return add_type_internal<T, SuperParametersT, true>(name, super.dt);
+    return add_type_internal<InheritedParametric<BaseT, T>, SuperParametersT>(name, super.dt);
   }
 }
 
@@ -1403,11 +1427,11 @@ auto Module::add_type(const std::string& name, CxxBaseTag<BaseT> super)
 /// The method ParametricTypeWrappers::apply(FunctorT&&) can then be used to add
 /// the wrappers for the class template methods.
 ///
-template<typename T, bool CxxInheritor, typename... AppliedTypesT>
+template<typename T, typename... AppliedTypesT>
 class ParametricTypeWrappers
 {
 public:
-  ParametricTypeWrappers(TypeWrapper<T, CxxInheritor>& base_wrapper):
+  ParametricTypeWrappers(TypeWrapper<T>& base_wrapper):
     m_generic_type(base_wrapper),
     m_specialized_types(std::make_tuple(create_type<AppliedTypesT>()...))
   {
@@ -1450,9 +1474,12 @@ private:
   TypeWrapper<AppliedT>
   create_type()
   {
-    static_assert(!CxxInheritor || !std::is_same_v<supertype<AppliedT>, AppliedT>,
-      "SuperType<T> must be specialized when using cxx_supertype(). "
-      "Add: template<> struct jlcxx::SuperType<T> { typedef Base type; };");
+    if constexpr(detail::IsInheritedParametric<T>::value)
+    {
+      static_assert(!std::is_same_v<supertype<AppliedT>, AppliedT>,
+        "SuperType<T> must be specialized when using julia_base_type(). "
+        "Add: template<> struct jlcxx::SuperType<T> { typedef Base type; };");
+    }
     static_assert(!IsMirroredType<AppliedT>::value, "Mirrored type templates can't be added using add_type and apply, you should explicitly disable mirroring for this type, e.g. define template<typename... T> struct IsMirroredType<Foo<T...>> : std::false_type { }; in the jlcxx namespace.");
 
     static constexpr int nb_julia_parameters = parameter_list<T>::nb_parameters;
@@ -1485,7 +1512,7 @@ private:
   }
 
 private:
-  TypeWrapper<T, CxxInheritor>& m_generic_type;
+  TypeWrapper<T>& m_generic_type;
   std::tuple<TypeWrapper<AppliedTypesT>...> m_specialized_types;
 };
 

--- a/include/jlcxx/type_conversion.hpp
+++ b/include/jlcxx/type_conversion.hpp
@@ -454,12 +454,21 @@ namespace detail
   };
 }
 
+/// Tag type for signalling C++ inheritance to add_type, enabling compile-time SuperType enforcement
+template<typename T>
+struct CxxBaseTag
+{
+  inline operator jl_datatype_t*() const { return dt; }
+  inline operator jl_value_t*() const { return (jl_value_t*)dt; }
+  jl_datatype_t* dt;
+};
+
 // Returns T itself for normal types, or the supertype for wrapped types, e.g. Foo instead of FooAllocated
 template<typename T>
-inline jl_datatype_t* julia_base_type()
+inline CxxBaseTag<T> julia_base_type()
 {
   create_if_not_exists<T>();
-  return detail::GetBaseT<T>::type();
+  return {detail::GetBaseT<T>::type()};
 }
 
 // Mapping for const references


### PR DESCRIPTION
This is an attempt to tackle the issue I encountered in #193, [where a missing `SuperType` specialization](https://github.com/JuliaInterop/libcxxwrap-julia/pull/193#issuecomment-3523459247) compiled fine, but led to runtime issues.

The basic idea is to add a new, recommended method/interface for `add_type` that explicitly states that C++ inheritance is being modeled (vs inheriting from a Julia-native abstract type):

```cpp
types.add_type<B>("B", jlcxx::cxx_supertype<A>());
```

where `cxx_supertype` returns a struct wrapping the `.dt()` pointer for the sake of dispatching to a different codepath containing the `SuperType` existence asserts. If accepted, the CxxWrap.jl documentation would be updated to recommend `cxx_supertype` for wrapped C++ types going forward.

This is opt-in, such that all* existing code using `julia_base_type` remains valid/the same, but without a compile-time check for existing `SuperType` specialization. (This shouldn't be a problem, since any/all existing code should already have  ncountered the aforementioned runtime issues.)

The asterisk is that I (with assistance from Claude) was unable to find a solution without modifying `TypeWrapper` or introducing a different return type for C++ inheriting wrapped types: `TypeWrapper<T>` becomes `TypeWrapper<T, bool CxxInheritor>`. 

Opened as a draft for discussion, since I'm not sure if the benefits are worth the breaking change to the `TypeWrapper` template.

Developed with Claude.
