### PR TITLE
Replace uses of SFINAE with concept/requires based equivalents [NFC]

### DIFF
--- a/include/jlcxx/attr.hpp
+++ b/include/jlcxx/attr.hpp
@@ -178,15 +178,12 @@ namespace detail
     return n_extra_kwarg == 0 || n_arg == n_extra_arg + n_extra_kwarg;
   }
 
-  /// simple helper for checking if a template argument has a call operator (e.g. is a lambda)
-  template<class T, typename SFINEA = void>
-  struct has_call_operator : std::false_type {};
-
+  /// Concept for checking if a template argument has a call operator (e.g. is a lambda)
   template<class T>
-  struct has_call_operator<T, std::void_t<decltype(&T::operator())>> : std::true_type {};
+  concept HasCallOperator = requires { &T::operator(); };
 
-  static_assert(!has_call_operator<const char*>::value);
-  static_assert(has_call_operator<std::function<void()>>::value);
+  static_assert(!HasCallOperator<const char*>);
+  static_assert(HasCallOperator<std::function<void()>>);
 }
 
 }

--- a/include/jlcxx/const_array.hpp
+++ b/include/jlcxx/const_array.hpp
@@ -68,14 +68,9 @@ ConstArray<T, sizeof...(SizesT)> make_const_array(const T* p, const SizesT... si
 
 struct ConstArrayTrait {};
 
-template<typename T, index_t N>
-struct TraitSelector<ConstArray<T,N>>
-{
-  using type = ConstArrayTrait;
-};
 
 template<typename T, index_t N>
-struct MappingTrait<ConstArray<T,N>, ConstArrayTrait>
+struct MappingTrait<ConstArray<T,N>>
 {
   using type = ConstArrayTrait;
 };

--- a/include/jlcxx/jlcxx_config.hpp
+++ b/include/jlcxx/jlcxx_config.hpp
@@ -18,6 +18,10 @@
 #define JLCXX_VERSION_MINOR 14
 #define JLCXX_VERSION_PATCH 9
 
+#if (defined(_MSVC_LANG) && _MSVC_LANG < 202002L) || (!defined(_MSVC_LANG) && __cplusplus < 202002L)
+#error "This library requires at least C++20"
+#endif
+
 // From https://stackoverflow.com/questions/5459868/concatenate-int-to-string-using-c-preprocessor
 #define __JLCXX_STR_HELPER(x) #x
 #define __JLCXX_STR(x) __JLCXX_STR_HELPER(x)

--- a/include/jlcxx/module.hpp
+++ b/include/jlcxx/module.hpp
@@ -582,8 +582,7 @@ public:
   }
 
   /// Define a new function. Overload for lambda
-  template<typename LambdaT, typename... Extra,
-           std::enable_if_t<detail::has_call_operator<LambdaT>::value && !std::is_member_function_pointer_v<LambdaT>, bool> = true>
+  template<detail::HasCallOperator LambdaT, typename... Extra>
   FunctionWrapperBase& method(const std::string& name, LambdaT&& lambda, Extra... extra)
   {
     detail::ExtraFunctionData extraData = detail::parse_attributes(extra...);
@@ -1150,8 +1149,7 @@ public:
   }
 
   /// Define a "constructor" using a lambda
-  template<typename LambdaT, typename... Extra,
-           std::enable_if_t<detail::has_call_operator<LambdaT>::value, bool> = true>
+  template<detail::HasCallOperator LambdaT, typename... Extra>
   TypeWrapper<T>& constructor(LambdaT&& lambda, Extra... extra)
   {
     m_module.constructor<T>(m_dt, std::forward<LambdaT>(lambda), &LambdaT::operator(), extra...);
@@ -1177,8 +1175,7 @@ public:
   }
 
   /// Define a "member" function using a lambda
-  template<typename LambdaT, typename... Extra,
-           std::enable_if_t<detail::has_call_operator<LambdaT>::value && !std::is_member_function_pointer_v<LambdaT>, bool> = true>
+  template<detail::HasCallOperator LambdaT, typename... Extra>
   TypeWrapper<T>& method(const std::string& name, LambdaT&& lambda, Extra... extra)
   {
     detail::ExtraFunctionData extraData = detail::parse_attributes(extra...);
@@ -1203,8 +1200,7 @@ public:
   }
 
   /// Overload operator() using a lambda
-  template<typename LambdaT, typename... Extra,
-           std::enable_if_t<detail::has_call_operator<LambdaT>::value, bool> = true>
+  template<detail::HasCallOperator LambdaT, typename... Extra>
   TypeWrapper<T>& method(LambdaT&& lambda, Extra... extra)
   {
     detail::ExtraFunctionData extraData = detail::parse_attributes(extra...);

--- a/include/jlcxx/smart_pointers.hpp
+++ b/include/jlcxx/smart_pointers.hpp
@@ -248,7 +248,8 @@ TypeWrapper1& add_smart_pointer(Module& mod, const std::string& name)
 struct SmartPointerTrait {};
 
 template<typename T>
-struct MappingTrait<T, std::enable_if_t<IsSmartPointerType<T>::value>>
+  requires IsSmartPointerType<T>::value
+struct MappingTrait<T>
 {
   using type = CxxWrappedTrait<SmartPointerTrait>;
 };

--- a/include/jlcxx/smart_pointers.hpp
+++ b/include/jlcxx/smart_pointers.hpp
@@ -151,35 +151,21 @@ struct SmartPtrMethods<PtrT<PointeeT, ExtraArgs...>, OtherPtrT>
   using ConstOtherPtrT = typename split_other_ptr<OtherPtrT>::const_other_t;
   using NonConstOtherPtrT = typename split_other_ptr<OtherPtrT>::other_t;
 
-  template<bool B, typename DummyT=void>
-  struct ConditionalConstructFromOther
-  {
-    static void apply(Module& mod)
-    {
-      mod.method("__cxxwrap_smartptr_construct_from_other", [] (SingletonType<WrappedT>, NonConstOtherPtrT& ptr) { return ConstructFromOther<WrappedT, NonConstOtherPtrT>::apply(ptr); });
-      mod.method("__cxxwrap_smartptr_construct_from_other", [] (SingletonType<ConstWrappedT>, ConstOtherPtrT& ptr) { return ConstructFromOther<ConstWrappedT, ConstOtherPtrT>::apply(ptr); });
-    }
-  };
-  template<typename DummyT> struct ConditionalConstructFromOther<false, DummyT> { static void apply(Module&) {} };
-
-  template<bool B, typename DummyT=void>
-  struct ConditionalCastToBase
-  {
-    static void apply(Module& mod)
-    {
-      mod.method("__cxxwrap_smartptr_cast_to_base", [] (const WrappedT& ptr) { return ConvertToBase<WrappedT>::apply(ptr); });
-      mod.method("__cxxwrap_smartptr_cast_to_base", [] (const ConstWrappedT& ptr) { return ConvertToBase<ConstWrappedT>::apply(ptr); });
-    }
-  };
-  template<typename DummyT> struct ConditionalCastToBase<false, DummyT> { static void apply(Module&) {} };
-
   static void apply(Module& mod)
   {
     assert(has_julia_type<WrappedT>());
     mod.set_override_module(get_cxxwrap_module());
     ConvertToConst<WrappedT>::wrap(mod);
-    ConditionalConstructFromOther<!std::is_same_v<OtherPtrT, NoSmartOther>>::apply(mod);
-    ConditionalCastToBase<!std::is_same_v<NonConstPointeeT,supertype<NonConstPointeeT>> && !std::is_same_v<std::unique_ptr<NonConstPointeeT>, WrappedT>>::apply(mod);
+    if constexpr (!std::is_same_v<OtherPtrT, NoSmartOther>)
+    {
+      mod.method("__cxxwrap_smartptr_construct_from_other", [] (SingletonType<WrappedT>, NonConstOtherPtrT& ptr) { return ConstructFromOther<WrappedT, NonConstOtherPtrT>::apply(ptr); });
+      mod.method("__cxxwrap_smartptr_construct_from_other", [] (SingletonType<ConstWrappedT>, ConstOtherPtrT& ptr) { return ConstructFromOther<ConstWrappedT, ConstOtherPtrT>::apply(ptr); });
+    }
+    if constexpr (!std::is_same_v<NonConstPointeeT, supertype<NonConstPointeeT>> && !std::is_same_v<std::unique_ptr<NonConstPointeeT>, WrappedT>)
+    {
+      mod.method("__cxxwrap_smartptr_cast_to_base", [] (const WrappedT& ptr) { return ConvertToBase<WrappedT>::apply(ptr); });
+      mod.method("__cxxwrap_smartptr_cast_to_base", [] (const ConstWrappedT& ptr) { return ConvertToBase<ConstWrappedT>::apply(ptr); });
+    }
     mod.unset_override_module();
   }
 };

--- a/include/jlcxx/stl.hpp
+++ b/include/jlcxx/stl.hpp
@@ -44,49 +44,6 @@ struct SkipIfSameAs<T,T>
 template<typename T1, typename T2> using skip_if_same = typename SkipIfSameAs<T1,T2>::type;
 
   
-// === is_default_insertable ===
-// https://stackoverflow.com/a/78556159
-template <typename, typename, typename = void>
-struct is_default_insertable
- : std::false_type {};
-
-template <typename T, typename A>
-struct is_default_insertable<
-  T, A,
-  std::void_t<decltype(std::allocator_traits<A>::construct(std::declval<A&>(), std::declval<T*>()))>
-  > : std::true_type {};
-  
-template <typename T, typename A>
-inline constexpr bool is_default_insertable_v = is_default_insertable<T, A>::value;
-
-// === is_copy_insertable ===
-template <typename, typename, typename = void>
-struct is_copy_insertable : std::false_type {};
-
-template <typename T, typename A>
-struct is_copy_insertable<
-  T, A,
-  std::void_t<
-    decltype(std::allocator_traits<A>::construct(std::declval<A&>(), std::declval<T*>(), std::declval<const T&>()))>
-  > : std::true_type {};
-
-template <typename T, typename A>
-inline constexpr bool is_copy_insertable_v = is_copy_insertable<T, A>::value;
-
-// === is_move_insertable ===
-template <typename, typename, typename = void>
-struct is_move_insertable
- : std::false_type {};
-
-template <typename T, typename A>
-struct is_move_insertable<
-  T, A,
-  std::void_t<decltype(std::allocator_traits<A>::construct(std::declval<A&>(), std::declval<T*>(), std::declval<T&&>()))>
-  > : std::true_type {};
-
-template <typename T, typename A>
-inline constexpr bool is_move_insertable_v = is_move_insertable<T, A>::value;
-
 // === is_std_allocator ===
 template <typename>
 struct is_std_allocator : std::false_type {};
@@ -97,16 +54,29 @@ struct is_std_allocator<std::allocator<T>> : std::true_type {};
 template <typename T>
 inline constexpr bool is_std_allocator_v = is_std_allocator<T>::value;
 
-// === uses_std_allocator ===
-template <typename C, typename = void>
-struct uses_std_allocator : std::false_type {};
+// === default_insertable ===
+// https://stackoverflow.com/a/78556159
+// Also requires default constructibility when using std::allocator, since it
+// internally calls the default constructor (which the allocator_traits check alone
+// does not verify). Custom allocators may not call the default constructor.
+template <typename T, typename C>
+concept default_insertable = requires (typename C::allocator_type a, T* p) {
+  std::allocator_traits<decltype(a)>::construct(a, p);
+  requires !is_std_allocator_v<decltype(a)> || std::is_default_constructible_v<T>;
+};
 
-template <typename C>
-struct uses_std_allocator<C, std::void_t<typename C::allocator_type>>
-    : is_std_allocator<typename C::allocator_type> {};
+// === copy_insertable ===
+template <typename T, typename C>
+concept copy_insertable = requires (typename C::allocator_type a, T* p, const T& v) {
+  std::allocator_traits<decltype(a)>::construct(a, p, v);
+  requires !is_std_allocator_v<decltype(a)> || std::is_copy_constructible_v<T>;
+};
 
-template <typename C>
-inline constexpr bool uses_std_allocator_v = uses_std_allocator<C>::value;
+// === move_insertable ===
+template <typename T, typename C>
+concept move_insertable = requires (typename C::allocator_type a, T* p, T&& v) {
+  std::allocator_traits<decltype(a)>::construct(a, p, std::move(v));
+};
 }
 
 namespace stl
@@ -380,20 +350,12 @@ struct WrapSTLContainer<std::vector> : STLTypeWrapperBase<WrapSTLContainer<std::
     // - Note: This is tested to be the case for std::deque in GCC 15.2.1
     // This cannot be checked in an if constexpr context prior to C++20, so we
     // simply remove the size_t constructor if the type is not default insertable.
-    // We also check std::is_default_constructible since std's allocator will
-    // internally call the default constructor (which is_default_insertable
-    // will not check). Custom allocators may not literally call the default
-    // constructor, so only check if the standard allocator is used.
-    if constexpr(jlcxx::detail::is_default_insertable_v<T, typename WrappedT::allocator_type>
-                 && (!jlcxx::detail::uses_std_allocator_v<WrappedT>
-                     || std::is_default_constructible_v<T>))
+    if constexpr(jlcxx::detail::default_insertable<T, WrappedT>)
     {
       wrapped.template constructor<std::size_t>();
     }
     // Similarly, we expose the count-copy constructor gated on CopyInsertible
-    if constexpr(jlcxx::detail::is_copy_insertable_v<T, typename WrappedT::allocator_type>
-                 && (!jlcxx::detail::uses_std_allocator_v<WrappedT>
-                     || std::is_copy_constructible_v<T>))
+    if constexpr(jlcxx::detail::copy_insertable<T, WrappedT>)
     {
       // Since references to Julia owned objects may be of incompatible types
       // and a copy will be performed anyway over the bindings, pass by
@@ -420,7 +382,7 @@ struct WrapSTLContainer<std::vector> : STLTypeWrapperBase<WrapSTLContainer<std::
     wrapped.method("append", [] (WrappedT& v, jlcxx::ArrayRef<T> arr)
     {
       const std::size_t addedlen = arr.size();
-      if constexpr(jlcxx::detail::is_move_insertable_v<T, typename WrappedT::allocator_type>)
+      if constexpr(jlcxx::detail::move_insertable<T, WrappedT>)
       {
         v.reserve(v.size() + addedlen);
       }
@@ -473,15 +435,11 @@ struct WrapSTLContainer<std::deque> : STLTypeWrapperBase<WrapSTLContainer<std::d
 
     wrap_range_based_bsearch(wrapped);
     // Similar to the std::vector check, we gate the additional constructors:
-    if constexpr(jlcxx::detail::is_default_insertable_v<T, typename WrappedT::allocator_type>
-                 && (!jlcxx::detail::uses_std_allocator_v<WrappedT>
-                     || std::is_default_constructible_v<T>))
+    if constexpr(jlcxx::detail::default_insertable<T, WrappedT>)
     {
       wrapped.template constructor<std::size_t>();
     }
-    if constexpr(jlcxx::detail::is_copy_insertable_v<T, typename WrappedT::allocator_type>
-                 && (!jlcxx::detail::uses_std_allocator_v<WrappedT>
-                     || std::is_copy_constructible_v<T>))
+    if constexpr(jlcxx::detail::copy_insertable<T, WrappedT>)
     {
       using BaseType = std::remove_const_t<std::remove_reference_t<T>>;
       wrapped.template constructor<std::size_t, BaseType>();

--- a/include/jlcxx/tuple.hpp
+++ b/include/jlcxx/tuple.hpp
@@ -61,40 +61,30 @@ namespace detail
 
 struct TupleTrait {};
 
-template<typename... TypesT>
-struct TraitSelector<std::tuple<TypesT...>>
-{
-  using type = TupleTrait;
-};
-
 // Tuples are always copied because the memory layout in C++ and Julia is different, so references and pointers are not allowed
 template<typename... TypesT>
-struct TraitSelector<std::tuple<TypesT...>&>
+struct MappingTrait<std::tuple<TypesT...>&>
 {
-  using type = TupleTrait;
   static_assert(sizeof(std::tuple<TypesT...>) == 0, "References to Julia tuples can't be used. Pass the tuple by value instead.");
 };
 template<typename... TypesT>
-struct TraitSelector<const std::tuple<TypesT...>&>
+struct MappingTrait<const std::tuple<TypesT...>&>
 {
-  using type = TupleTrait;
   static_assert(sizeof(std::tuple<TypesT...>) == 0, "References to Julia tuples can't be used. Pass the tuple by value instead.");
 };
 template<typename... TypesT>
-struct TraitSelector<std::tuple<TypesT...>*>
+struct MappingTrait<std::tuple<TypesT...>*>
 {
-  using type = TupleTrait;
   static_assert(sizeof(std::tuple<TypesT...>) == 0, "Pointers to Julia tuples can't be used. Pass the tuple by value instead.");
 };
 template<typename... TypesT>
-struct TraitSelector<const std::tuple<TypesT...>*>
+struct MappingTrait<const std::tuple<TypesT...>*>
 {
-  using type = TupleTrait;
   static_assert(sizeof(std::tuple<TypesT...>) == 0, "Pointers to Julia tuples can't be used. Pass the tuple by value instead.");
 };
 
 template<typename... TypesT>
-struct MappingTrait<std::tuple<TypesT...>, TupleTrait>
+struct MappingTrait<std::tuple<TypesT...>>
 {
   using type = TupleTrait;
 };
@@ -153,14 +143,9 @@ struct NTuple
 {
 };
 
-template<typename N, typename T>
-struct TraitSelector<NTuple<N,T>>
-{
-  using type = TupleTrait;
-};
 
 template<typename N, typename T>
-struct MappingTrait<NTuple<N,T>, TupleTrait>
+struct MappingTrait<NTuple<N,T>>
 {
   using type = TupleTrait;
 };

--- a/include/jlcxx/type_conversion.hpp
+++ b/include/jlcxx/type_conversion.hpp
@@ -187,13 +187,7 @@ struct DirectPtrTrait {}; // Some pointers are returned directly, e.g. jl_value_
 
 struct NoCxxWrappedSubtrait {};
 
-// Helper to avoid ambiguous specializations
-template<typename T> struct TraitSelector
-{
-  using type = void;
-};
-
-template<typename T, typename Enable=typename TraitSelector<T>::type>
+template<typename T>
 struct MappingTrait
 {
   using type = NoMappingTrait;
@@ -236,7 +230,8 @@ struct MappingTrait<FILE*>
 };
 
 template<typename T>
-struct MappingTrait<T, std::enable_if_t<!IsMirroredType<T>::value && !IsSmartPointerType<T>::value>>
+  requires (!IsMirroredType<T>::value && !IsSmartPointerType<T>::value)
+struct MappingTrait<T>
 {
   using type = CxxWrappedTrait<NoCxxWrappedSubtrait>;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
 add_executable(test_module test_module.cpp)
-set_property(TARGET test_module PROPERTY COMPILE_FLAGS "-std=c++17")
 if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
   set_property(TARGET test_module PROPERTY LINK_OPTIONS "-pthread")
 endif()


### PR DESCRIPTION
Aside from the first commit[^1], each commit replaces independent instances of the SFINAE
pattern with named concepts and/or `requires` statements. I find that concepts/`requires`
are much more directly readable and easier to reason about, but I completely understand if
the code churn isn't worth it.

[^1]: 29c435c removes a remnant C++17 flag which is no longer correct, as libcxxwrap is
    documented as having a minimum standard of C++20. (Setting the compilation flag manually
    bypasses the CMake functionality that should've prevented this.) I strengthened min
    standard requirement by adding a check in the headers. That check also protects
    non-CMake consumers of libcxxwrap, because the C++20 requirement in the CMake config is
    imposed within CMake, and not at a header/shared library level.
