### PR TITLE
Fix ambiguous `Val<T, v>` specializations on some compilers (Clang 20+)

### DIFF
--- a/include/jlcxx/type_conversion.hpp
+++ b/include/jlcxx/type_conversion.hpp
@@ -1042,7 +1042,10 @@ struct static_type_mapping<Val<T, v>>
   using type = jl_datatype_t*;
 };
 
+// Needs constraint because Clang 20+ deduces and ranks both Val specializations
+// equally, making it ambiguous with the one below.
 template<typename T, T v>
+  requires (!std::is_reference_v<T>)
 struct julia_type_factory<Val<T, v>>
 {
   static inline jl_datatype_t* julia_type()
@@ -1069,7 +1072,9 @@ struct ConvertToCpp<Val<T, v>, NoMappingTrait>
   }
 };
 
+// Constrained for the same reason as julia_type_factory<Val<T, v>> above.
 template<typename T, T v>
+  requires (!std::is_reference_v<T>)
 struct ConvertToJulia<Val<T, v>, NoMappingTrait>
 {
   jl_datatype_t* operator()(Val<T, v>) const


### PR DESCRIPTION

Clang 20 and later introduce deduction of generic `julia_type_factory<Val<T, v>>` and `ConvertToJulia<Val<T, v>>` templates for ref-types too, which then makes the partial specialization for `const std::string_view&` ambiguous. This is the cause of the failed macOS aarch64 CI jobs in #207 (built with Clang 21).

`!is_reference_v<T>` is the technically/broadly correct constraint (vs more obvious `!std::is_same_v<T, const std::string_view&>`): For any reference `T`, `box<T>(v)` returns a `BoxedValue`, which does not cast to `jl_datatype_t*`, so a reference-typed `Val` has never worked without its own specialization. The `string_view` constraint would need extends for any external/future specializations.

The following MWE reproduces the relevant ambiguity error on Clang 20 without the constraint:

```cpp
#include <string_view>
#include <type_traits>

template <typename T, T v> struct Val {};
static constexpr const std::string_view sym = "x";

template <typename T> struct Fac;

template <typename T, T v>
  requires(!std::is_reference_v<T>)
struct Fac<Val<T, v>> {
  static constexpr int f() { return 1; }
};

template <const std::string_view &s>
struct Fac<Val<const std::string_view &, s>> {
  static constexpr int f() { return 2; }
};

static_assert(Fac<Val<int, 7>>::f() == 1);
static_assert(Fac<Val<const std::string_view &, sym>>::f() == 2);

int main() {};
```