### PR TITLE
Update requested Visual Studio version for windows-latest image

### DIFF
--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -G "Visual Studio 17 2022" -A x64 -DOVERRIDES_PATH=$HOMEDRIVE/$HOMEPATH/.julia/artifacts/Overrides.toml -DOVERRIDE_ROOT=./ -DAPPEND_OVERRIDES_TOML=ON ..
+          cmake -G "Visual Studio 18 2026" -A x64 -DOVERRIDES_PATH=$HOMEDRIVE/$HOMEPATH/.julia/artifacts/Overrides.toml -DOVERRIDE_ROOT=./ -DAPPEND_OVERRIDES_TOML=ON ..
           package="$(echo "$body" | sed -n '1p')"
           if [[ ! "${package}" =~ ^https:// ]]; then
             package="https://github.com/JuliaInterop/CxxWrap.jl.git"


### PR DESCRIPTION
Fixes failing windows CI in recent runs because `windows-latest` now contains Visual Studio 18 2026.
